### PR TITLE
Add support for relative $schema paths

### DIFF
--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -452,11 +452,13 @@ export default createRule("no-invalid", {
             return typeof $schema === "string"
                 ? $schema.startsWith(".")
                     ? path.resolve(
-                        path.dirname(
-                            typeof context.getPhysicalFilename === 'function' ? context.getPhysicalFilename() : getPhysicalFilename(context.getFilename()),
-                        ),
-                        $schema,
-                    )
+                          path.dirname(
+                              typeof context.getPhysicalFilename === "function"
+                                  ? context.getPhysicalFilename()
+                                  : getPhysicalFilename(context.getFilename()),
+                          ),
+                          $schema,
+                      )
                     : $schema
                 : null
         }

--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -453,7 +453,7 @@ export default createRule("no-invalid", {
                 ? $schema.startsWith(".")
                     ? path.resolve(
                         path.dirname(
-                            getPhysicalFilename(context.getFilename()),
+                            typeof context.getPhysicalFilename === 'function' ? context.getPhysicalFilename() : getPhysicalFilename(context.getFilename()),
                         ),
                         $schema,
                     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,26 +212,26 @@ type CursorWithSkipOptions =
     | number
     | FilterPredicate
     | {
-        includeComments?: boolean
-        filter?: FilterPredicate
-        skip?: number
-    }
+          includeComments?: boolean
+          filter?: FilterPredicate
+          skip?: number
+      }
 
 type CursorWithCountOptions =
     | number
     | FilterPredicate
     | {
-        includeComments?: boolean
-        filter?: FilterPredicate
-        count?: number
-    }
+          includeComments?: boolean
+          filter?: FilterPredicate
+          count?: number
+      }
 
 interface ReportDescriptorOptionsBase {
     data?: { [key: string]: string }
 
     fix?:
-    | null
-    | ((fixer: RuleFixer) => null | Fix | IterableIterator<Fix> | Fix[])
+        | null
+        | ((fixer: RuleFixer) => null | Fix | IterableIterator<Fix> | Fix[])
 }
 
 type SuggestionDescriptorMessage = { desc: string } | { messageId: string }

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export interface RuleContext {
     }
     getAncestors(): Node[]
     getFilename(): string
+    getPhysicalFilename?: () => string
     getSourceCode(): SourceCode
     report(descriptor: ReportDescriptor): void
     // eslint@6 does not have this method.
@@ -211,26 +212,26 @@ type CursorWithSkipOptions =
     | number
     | FilterPredicate
     | {
-          includeComments?: boolean
-          filter?: FilterPredicate
-          skip?: number
-      }
+        includeComments?: boolean
+        filter?: FilterPredicate
+        skip?: number
+    }
 
 type CursorWithCountOptions =
     | number
     | FilterPredicate
     | {
-          includeComments?: boolean
-          filter?: FilterPredicate
-          count?: number
-      }
+        includeComments?: boolean
+        filter?: FilterPredicate
+        count?: number
+    }
 
 interface ReportDescriptorOptionsBase {
     data?: { [key: string]: string }
 
     fix?:
-        | null
-        | ((fixer: RuleFixer) => null | Fix | IterableIterator<Fix> | Fix[])
+    | null
+    | ((fixer: RuleFixer) => null | Fix | IterableIterator<Fix> | Fix[])
 }
 
 type SuggestionDescriptorMessage = { desc: string } | { messageId: string }

--- a/tests/fixtures/rules/no-invalid/invalid/$schema-test/json-relative-errors.json
+++ b/tests/fixtures/rules/no-invalid/invalid/$schema-test/json-relative-errors.json
@@ -1,0 +1,9 @@
+[
+    {
+        "message": "\"theAnswer\" must be number.",
+        "line": 4,
+        "column": 5,
+        "endLine": 4,
+        "endColumn": 16
+    }
+]

--- a/tests/fixtures/rules/no-invalid/invalid/$schema-test/json-relative-input.json
+++ b/tests/fixtures/rules/no-invalid/invalid/$schema-test/json-relative-input.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../../../utils/test.schema.json",
+    "theAnswer": {}
+}

--- a/tests/fixtures/rules/no-invalid/invalid/$schema-test/toml-relative-errors.json
+++ b/tests/fixtures/rules/no-invalid/invalid/$schema-test/toml-relative-errors.json
@@ -1,0 +1,9 @@
+[
+    {
+        "message": "\"theAnswer\" must be number.",
+        "line": 3,
+        "column": 1,
+        "endLine": 3,
+        "endColumn": 10
+    }
+]

--- a/tests/fixtures/rules/no-invalid/invalid/$schema-test/toml-relative-input.toml
+++ b/tests/fixtures/rules/no-invalid/invalid/$schema-test/toml-relative-input.toml
@@ -1,0 +1,2 @@
+"$schema" = "../../../../utils/test.schema.json"
+theAnswer = {}

--- a/tests/fixtures/rules/no-invalid/invalid/$schema-test/yaml-relative-errors.json
+++ b/tests/fixtures/rules/no-invalid/invalid/$schema-test/yaml-relative-errors.json
@@ -1,0 +1,9 @@
+[
+    {
+        "message": "\"theAnswer\" must be number.",
+        "line": 3,
+        "column": 1,
+        "endLine": 3,
+        "endColumn": 10
+    }
+]

--- a/tests/fixtures/rules/no-invalid/invalid/$schema-test/yaml-relative-input.yaml
+++ b/tests/fixtures/rules/no-invalid/invalid/$schema-test/yaml-relative-input.yaml
@@ -1,2 +1,2 @@
-$schema: "../../../../utils/test.schema.json"
+$schema: ../../../../utils/test.schema.json
 theAnswer: {}

--- a/tests/fixtures/rules/no-invalid/invalid/$schema-test/yaml-relative-input.yaml
+++ b/tests/fixtures/rules/no-invalid/invalid/$schema-test/yaml-relative-input.yaml
@@ -1,0 +1,2 @@
+$schema: "../../../../utils/test.schema.json"
+theAnswer: {}

--- a/tests/fixtures/rules/no-invalid/valid/$schema-test/json-relative-input.json
+++ b/tests/fixtures/rules/no-invalid/valid/$schema-test/json-relative-input.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "../../../../utils/test.schema.json",
+    "theAnswer": 42
+}

--- a/tests/fixtures/rules/no-invalid/valid/$schema-test/toml-relative-input.toml
+++ b/tests/fixtures/rules/no-invalid/valid/$schema-test/toml-relative-input.toml
@@ -1,0 +1,2 @@
+"$schema" = "../../../../utils/test.schema.json"
+theAnswer = 42

--- a/tests/fixtures/rules/no-invalid/valid/$schema-test/yaml-relative-input.yaml
+++ b/tests/fixtures/rules/no-invalid/valid/$schema-test/yaml-relative-input.yaml
@@ -1,0 +1,2 @@
+$schema: "../../../../utils/test.schema.json"
+theAnswer: 42

--- a/tests/fixtures/rules/no-invalid/valid/$schema-test/yaml-relative-input.yaml
+++ b/tests/fixtures/rules/no-invalid/valid/$schema-test/yaml-relative-input.yaml
@@ -1,2 +1,2 @@
-$schema: "../../../../utils/test.schema.json"
+$schema: ../../../../utils/test.schema.json
 theAnswer: 42

--- a/tests/fixtures/utils/test.schema.json
+++ b/tests/fixtures/utils/test.schema.json
@@ -1,20 +1,20 @@
 {
-  "$id": "https://example.com/test.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema",
-  "title": "Test",
-  "type": "object",
-  "properties": {
-    "$schema": {
-      "type": "string",
-      "description": "The schema's URI"
+    "$id": "https://example.com/test.schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "Test",
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "description": "The schema's URI"
+        },
+        "theAnswer": {
+            "type": "number",
+            "description": "The Answer to the Ultimate Question of Life, the Universe, and Everything",
+            "minimum": 42,
+            "maximum": 42
+        }
     },
-    "theAnswer": {
-      "type": "number",
-      "description": "The Answer to the Ultimate Question of Life, the Universe, and Everything",
-      "minimum": 42,
-      "maximum": 42
-    }
-  },
-  "additionalProperties": false,
-  "required": ["$schema", "theAnswer"]
+    "additionalProperties": false,
+    "required": ["$schema", "theAnswer"]
 }

--- a/tests/fixtures/utils/test.schema.json
+++ b/tests/fixtures/utils/test.schema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://example.com/test.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "The schema's URI"
+    },
+    "theAnswer": {
+      "type": "number",
+      "description": "The Answer to the Ultimate Question of Life, the Universe, and Everything",
+      "minimum": 42,
+      "maximum": 42
+    }
+  },
+  "additionalProperties": false,
+  "required": ["$schema", "theAnswer"]
+}

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -268,7 +268,7 @@ function getConfig(ruleName: string, inputFile: string) {
         return Object.assign(
             { parser: require.resolve(getParserName(inputFile)) },
             config,
-            { code, filename },
+            { code, filename: inputFile },
         )
     }
     // inline config
@@ -296,7 +296,7 @@ function getConfig(ruleName: string, inputFile: string) {
     return Object.assign(
         { parser: require.resolve(getParserName(inputFile)) },
         config,
-        { code, filename },
+        { code, filename: inputFile },
     )
 }
 


### PR DESCRIPTION
I also fixed an issue with the tests. The filename being passed in to eslint by the tests was only a partial path in most circumstances, and this fix needs `context.getFilename()` to return a full path. I'm not very familiar with eslint, so if there is a better way to do this, let me know.