### PR TITLE
Updated the readme with latest version of node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install --save-dev eslint eslint-plugin-jsonc eslint-plugin-json-schema-vali
 > **Requirements**
 >
 > - ESLint v6.0.0 and above
-> - Node.js v14.17.x, v16.x and above
+> - Node.js v14.18.x, v16.x and above
 
 <!--DOCS_IGNORE_END-->
 


### PR DESCRIPTION
I see that in the latest version, we dropped support for node.js versions  <14.18.0 but didn't update the readme so I decided to do just that.