### PR TITLE
fix: catalog could be `null`

### DIFF
--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -90,6 +90,10 @@ function parseOption(
         // If it matches the user's definition, don't use `catalog.json`.
         if (option.useSchemastoreCatalog !== false) {
             const catalog = loadJson(CATALOG_URL, context)
+            if (!catalog) {
+                return null
+            }
+
             const schemas: {
                 name?: string
                 description?: string


### PR DESCRIPTION
fix #170

This issue exists because `T = any` by default in `loadJson`, maybe it should have no default type, and we should specific the type at usage.