### PR TITLE
feat: support schema merging

### DIFF
--- a/.changeset/fluffy-jeans-whisper.md
+++ b/.changeset/fluffy-jeans-whisper.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-json-schema-validator": patch
+---
+
+feat: support schema merging

--- a/.changeset/fluffy-jeans-whisper.md
+++ b/.changeset/fluffy-jeans-whisper.md
@@ -1,5 +1,5 @@
 ---
-"eslint-plugin-json-schema-validator": patch
+"eslint-plugin-json-schema-validator": minor
 ---
 
 feat: support schema merging

--- a/docs/rules/no-invalid.md
+++ b/docs/rules/no-invalid.md
@@ -54,7 +54,8 @@ This rule validates the file with JSON Schema and reports errors.
                     "schema": {/* JSON Schema Definition */} // or string
                 }
             ],
-            "useSchemastoreCatalog": true
+            "useSchemastoreCatalog": true,
+            "mergeSchemas": true // or ["$schema", "options", "catalog"]
         }
     ]
 }
@@ -64,6 +65,7 @@ This rule validates the file with JSON Schema and reports errors.
   - `fileMatch` ... A list of known file names (or globs) that match the schema.
   - `schema` ... An object that defines a JSON schema. Or the path of the JSON schema file or URL.
 - `useSchemastoreCatalog` ... If `true`, it will automatically configure some schemas defined in [https://www.schemastore.org/api/json/catalog.json](https://www.schemastore.org/api/json/catalog.json). Default `true`
+- `mergeSchemas` ... If `true`, it will merge all schemas defined in `schemas`, at the `$schema` field within files, and the catalogue. If an array is given, it will merge only schemas from the given sources. Default `false`
 
 This option can also be given a JSON schema file or URL. This is useful for configuring with the `/* eslint */` directive comments.
 

--- a/tests/src/rules/no-invalid.ts
+++ b/tests/src/rules/no-invalid.ts
@@ -78,6 +78,67 @@ tester.run(
           ],
         },
         {
+          filename: path.join(__dirname, ".eslintrc.json"),
+          code: '{ "extends": [ 42 ], "$schema": "https://json.schemastore.org/eslintrc" }',
+          options: [
+            {
+              schemas: [
+                {
+                  fileMatch: ["tests/src/rules/.eslintrc.json"],
+                  schema: {
+                    properties: {
+                      foo: {
+                        type: "number",
+                      },
+                    },
+                    required: ["foo"],
+                  },
+                },
+              ],
+              mergeSchemas: true,
+              useSchemastoreCatalog: false,
+            },
+          ],
+          errors: [
+            "Root must have required property 'foo'.",
+            '"extends" must be string.',
+            '"extends" must match exactly one schema in oneOf.',
+            '"extends[0]" must be string.',
+          ],
+        },
+        {
+          filename: path.join(__dirname, "version.json"),
+          code: '{ "extends": [ 42 ], "$schema": "https://json.schemastore.org/eslintrc" }',
+          options: [
+            {
+              schemas: [
+                {
+                  fileMatch: ["tests/src/rules/version.json"],
+                  schema: {
+                    properties: {
+                      foo: {
+                        type: "number",
+                      },
+                    },
+                    required: ["foo"],
+                  },
+                },
+              ],
+              mergeSchemas: true,
+              useSchemastoreCatalog: true,
+            },
+          ],
+          errors: [
+            "Root must have required property 'foo'.",
+            "Root must have required property 'version'.",
+            "Root must have required property 'inherit'.",
+            "Root must match a schema in anyOf.",
+            '"extends" must be string.',
+            '"extends" must match exactly one schema in oneOf.',
+            '"extends[0]" must be string.',
+          ],
+        },
+        {
           filename: path.join(__dirname, ".prettierrc.toml"),
           code: `
 trailingComma = "es3"


### PR DESCRIPTION
Hi! Here the PR :) 

Implements the new rule option `mergeSchemas`:
```json
{
  "mergeSchemas": ["$schema", "options", "catalog"] // or true as shorthand for all three
}
```

Schemas will be validated as logical AND, meaning all of them must be satisfied.

- [x] Documentation updated
- [x] Test cases added

Would be great to see this merged! If you would want any changes, please let me know.

Closes #235 