### PR TITLE
fix: `useSchemastoreCatalog` is enabled by default according to docs.

### DIFF
--- a/.changeset/sixty-mice-arrive.md
+++ b/.changeset/sixty-mice-arrive.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-json-schema-validator": major
+---
+
+fix: `useSchemastoreCatalog` is enabled by default according to docs.

--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -403,7 +403,8 @@ export default createRule("no-invalid", {
       relativeFilename: string,
     ): Validator[] | null {
       const option = context.options[0] || {};
-      if (!option.useSchemastoreCatalog) {
+      const useSchemastoreCatalog = option.useSchemastoreCatalog !== false;
+      if (!useSchemastoreCatalog) {
         return null;
       }
 

--- a/tests/src/rules/no-invalid.ts
+++ b/tests/src/rules/no-invalid.ts
@@ -45,6 +45,15 @@ tester.run(
         {
           filename: ".eslintrc.json",
           code: '{ "extends": [ 42 ] }',
+          errors: [
+            '"extends" must be string.',
+            '"extends" must match exactly one schema in oneOf.',
+            '"extends[0]" must be string.',
+          ],
+        },
+        {
+          filename: ".eslintrc.json",
+          code: '{ "extends": [ 42 ] }',
           options: [
             {
               schemas: [


### PR DESCRIPTION
This is a fix for an unintentional change in default behavior in 4.6.