### PR TITLE
Refine flat config types

### DIFF
--- a/.changeset/proud-vans-bake.md
+++ b/.changeset/proud-vans-bake.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-json-schema-validator": minor
+---
+
+feat: improved compatibility with `@types/eslint` for flat config.

--- a/src/configs/flat/base.ts
+++ b/src/configs/flat/base.ts
@@ -1,4 +1,4 @@
-import type { ESLint } from "eslint";
+import type { ESLint, Linter } from "eslint";
 import * as jsoncParser from "jsonc-eslint-parser";
 import * as yamlParser from "yaml-eslint-parser";
 import * as tomlParser from "toml-eslint-parser";
@@ -54,4 +54,4 @@ export default [
       "spaced-comment": "off",
     },
   },
-];
+] satisfies Linter.FlatConfig[] as Linter.FlatConfig[];

--- a/src/configs/flat/recommended.ts
+++ b/src/configs/flat/recommended.ts
@@ -1,3 +1,4 @@
+import type { Linter } from "eslint";
 import base from "./base";
 export default [
   ...base,
@@ -7,4 +8,4 @@ export default [
       "json-schema-validator/no-invalid": "warn",
     },
   },
-];
+] satisfies Linter.FlatConfig[];

--- a/tools/update-rulesets.ts
+++ b/tools/update-rulesets.ts
@@ -56,6 +56,7 @@ export = {
 
 for (const rec of ["recommended"] as const) {
   let content = `
+import type { Linter } from "eslint";
 import base from './base';
 export default [
   ...base,
@@ -76,7 +77,7 @@ export default [
         .join(",\n")}
     },
   }
-]
+] satisfies Linter.FlatConfig[]
 `;
 
   const filePath = path.resolve(__dirname, FLAT_RULESET_NAME[rec]);


### PR DESCRIPTION
See also https://github.com/ota-meshi/eslint-plugin-toml/pull/204

Typescript has issues inferring the type of `base.ts`'s export so an additional assertion follows the `satisfies` statement. This also causes the type of both of the flat configs to collapse into `Linter.FlatConfig[]` in the resulting declaration file.