### PR TITLE
fix: don't crash if schema cache directories already exist

### DIFF
--- a/.changeset/five-dodos-cheat.md
+++ b/.changeset/five-dodos-cheat.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-json-schema-validator": patch
+---
+
+fix: don't crash if schema cache directories already exist

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -127,7 +127,7 @@ function loadJsonFromURL<T>(
   const httpRequestOptions = options?.requestOptions ?? {};
   const httpGetModulePath = resolvePath(options?.getModulePath, context);
 
-  makeDirs(path.dirname(jsonFilePath));
+  fs.mkdirSync(path.dirname(jsonFilePath), { recursive: true });
 
   let data, timestamp;
   try {
@@ -209,20 +209,6 @@ function postProcess<T>(
   delete require.cache[jsonFilePath];
 
   return data;
-}
-
-/**
- * Make directories
- */
-function makeDirs(dir: string) {
-  const dirs = [dir];
-  while (!fs.existsSync(dirs[0])) {
-    dirs.unshift(path.dirname(dirs[0]));
-  }
-  dirs.shift();
-  for (const dir of dirs) {
-    fs.mkdirSync(dir);
-  }
 }
 
 /**


### PR DESCRIPTION
👋 Hi there. Thank you for creating the library. It's super useful!

One problem I noticed happening in our GitHub CI process is that it crashed sometimes and the error was:

```
Error while loading rule 'json-schema-validator/no-invalid': EEXIST: file already exists, mkdir 'node_modules/eslint-plugin-json-schema-validator/.cached_schemastore'
```

Which was caused by `fs.mkdirSync` throwing an error when a directory already exists. 

I swapped this with `fs.mkdirSync('<path to dir>', { recursive: true })` which will not throw if the directory exists AND has the added benefit that it automatically creates any missing parent directory which means you don't need the `makeDirs` helper function.