### PR TITLE
fix: update schemastore catlog url

### DIFF
--- a/.changeset/eight-timers-tickle.md
+++ b/.changeset/eight-timers-tickle.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-json-schema-validator": patch
+---
+
+fix: update schemastore catlog url

--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -25,7 +25,7 @@ import fs from "fs";
 import { getCwd, getFilename, getSourceCode } from "../utils/compat";
 import { toCompatCreate } from "eslint-json-compat-utils";
 
-const CATALOG_URL = "https://json.schemastore.org/schema-catalog.json";
+const CATALOG_URL = "https://json.schemastore.org/schema-catalog.json/api/json/catalog.json";
 
 /**
  * Checks if match file

--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -25,7 +25,7 @@ import fs from "fs";
 import { getCwd, getFilename, getSourceCode } from "../utils/compat";
 import { toCompatCreate } from "eslint-json-compat-utils";
 
-const CATALOG_URL = "https://www.schemastore.org/api/json/catalog.json";
+const CATALOG_URL = "https://json.schemastore.org/schema-catalog.json";
 
 /**
  * Checks if match file

--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -25,7 +25,7 @@ import fs from "fs";
 import { getCwd, getFilename, getSourceCode } from "../utils/compat";
 import { toCompatCreate } from "eslint-json-compat-utils";
 
-const CATALOG_URL = "https://json.schemastore.org/schema-catalog.json/api/json/catalog.json";
+const CATALOG_URL = "https://json.schemastore.org/api/json/catalog.json";
 
 /**
  * Checks if match file


### PR DESCRIPTION
close #386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the URL used to load the JSON schema catalog, ensuring continued access to the latest schema definitions.
- **Refactor**
  - Improved type safety and code clarity by refining type usage and import organization without changing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->