### PR TITLE
Configurable schema cache location and TTL

### DIFF
--- a/.changeset/cache-config-options.md
+++ b/.changeset/cache-config-options.md
@@ -9,8 +9,3 @@ New `settings["json-schema-validator"].cache` options:
 - `path` — where cached schemas are stored (relative to cwd, or absolute).
 - `ttl` — how long before a cached schema is refetched (ms number or a
   duration string like `"12h"` / `"1d"`).
-
-The default cache location has moved out of `node_modules` into the OS user
-cache directory, so it now persists across runs (fixes the Docker use case in
-#180). Existing setups keep the 1-day TTL; the only effect of the moved default
-is a one-time refetch of schemas.

--- a/.changeset/cache-config-options.md
+++ b/.changeset/cache-config-options.md
@@ -1,0 +1,16 @@
+---
+"eslint-plugin-json-schema-validator": minor
+---
+
+feat: add configurable schemastore cache location and TTL
+
+New `settings["json-schema-validator"].cache` options:
+
+- `path` — where cached schemas are stored (relative to cwd, or absolute).
+- `ttl` — how long before a cached schema is refetched (ms number or a
+  duration string like `"12h"` / `"1d"`).
+
+The default cache location has moved out of `node_modules` into the OS user
+cache directory, so it now persists across runs (fixes the Docker use case in
+#180). Existing setups keep the 1-day TTL; the only effect of the moved default
+is a one-time refetch of schemas.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ module.exports = {
         getModulePath: "",
         requestOptions: {},
       },
+      cache: {
+        path: "",
+        ttl: "1d",
+      },
     },
   },
 };
@@ -159,6 +163,9 @@ module.exports = {
 - `http` ... Settings to resolve schema URLs.
   - `getModulePath` ... Module path to `GET` the URL. The default implementation is [./src/utils/http-client/get-modules/http.ts](https://github.com/ota-meshi/eslint-plugin-json-schema-validator/blob/main/src/utils/http-client/get-modules/http.ts).
   - `requestOptions` ... Options used in the module.
+- `cache` ... Settings for the schemastore cache used when resolving remote schema URLs.
+  - `path` ... Directory to store cached schemas. A relative path is resolved against the current working directory; an absolute path is used as-is. When unset, the OS user cache directory is used (`$XDG_CACHE_HOME` / `~/.cache`, `~/Library/Caches`, or `%LOCALAPPDATA%`) under an `eslint-plugin-json-schema-validator` subfolder.
+  - `ttl` ... How long a cached schema is used before it is refetched. A number is milliseconds; a string is a duration such as `"30m"`, `"12h"`, `"1d"`, or `"2w"`. Defaults to 1 day. Use `0` to always refetch.
 
 #### Example of `http`
 
@@ -199,6 +206,25 @@ module.exports = {
           // Example of proxy settings.
           proxy: "http://my.proxy.com:8080/",
         },
+      },
+    },
+  },
+};
+```
+
+#### Example of `cache`
+
+Persist the cache to a directory that survives between runs (for example a mounted Docker volume), and refetch weekly:
+
+<!-- eslint-skip -->
+
+```js
+module.exports = {
+  settings: {
+    "json-schema-validator": {
+      cache: {
+        path: "/cache/eslint-json-schema-validator",
+        ttl: "1w",
       },
     },
   },

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ module.exports = {
   - `getModulePath` ... Module path to `GET` the URL. The default implementation is [./src/utils/http-client/get-modules/http.ts](https://github.com/ota-meshi/eslint-plugin-json-schema-validator/blob/main/src/utils/http-client/get-modules/http.ts).
   - `requestOptions` ... Options used in the module.
 - `cache` ... Settings for the schemastore cache used when resolving remote schema URLs.
-  - `path` ... Directory to store cached schemas. A relative path is resolved against the current working directory; an absolute path is used as-is. When unset, the OS user cache directory is used (`$XDG_CACHE_HOME` / `~/.cache`, `~/Library/Caches`, or `%LOCALAPPDATA%`) under an `eslint-plugin-json-schema-validator` subfolder.
+  - `path` ... Directory to store cached schemas. A relative path is resolved against the current working directory; an absolute path is used as-is. When unset, the default location alongside the installed package is used.
   - `ttl` ... How long a cached schema is used before it is refetched. A number is milliseconds; a string is a duration such as `"30m"`, `"12h"`, `"1d"`, or `"2w"`. Defaults to 1 day. Use `0` to always refetch.
 
 #### Example of `http`

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -118,7 +118,7 @@ module.exports = {
   - `getModulePath` ... Module path to `GET` the URL. The default implementation is [./src/utils/http-client/get-modules/http.ts](https://github.com/ota-meshi/eslint-plugin-json-schema-validator/blob/main/src/utils/http-client/get-modules/http.ts).
   - `requestOptions` ... Options used in the module.
 - `cache` ... Settings for the schemastore cache used when resolving remote schema URLs.
-  - `path` ... Directory to store cached schemas. A relative path is resolved against the current working directory; an absolute path is used as-is. When unset, the OS user cache directory is used (`$XDG_CACHE_HOME` / `~/.cache`, `~/Library/Caches`, or `%LOCALAPPDATA%`) under an `eslint-plugin-json-schema-validator` subfolder.
+  - `path` ... Directory to store cached schemas. A relative path is resolved against the current working directory; an absolute path is used as-is. When unset, the default location alongside the installed package is used.
   - `ttl` ... How long a cached schema is used before it is refetched. A number is milliseconds; a string is a duration such as `"30m"`, `"12h"`, `"1d"`, or `"2w"`. Defaults to 1 day. Use `0` to always refetch.
 
 #### Example of `http`

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -105,6 +105,10 @@ module.exports = {
         getModulePath: "",
         requestOptions: {},
       },
+      cache: {
+        path: "",
+        ttl: "1d",
+      },
     },
   },
 };
@@ -113,6 +117,9 @@ module.exports = {
 - `http` ... Settings to resolve schema URLs.
   - `getModulePath` ... Module path to `GET` the URL. The default implementation is [./src/utils/http-client/get-modules/http.ts](https://github.com/ota-meshi/eslint-plugin-json-schema-validator/blob/main/src/utils/http-client/get-modules/http.ts).
   - `requestOptions` ... Options used in the module.
+- `cache` ... Settings for the schemastore cache used when resolving remote schema URLs.
+  - `path` ... Directory to store cached schemas. A relative path is resolved against the current working directory; an absolute path is used as-is. When unset, the OS user cache directory is used (`$XDG_CACHE_HOME` / `~/.cache`, `~/Library/Caches`, or `%LOCALAPPDATA%`) under an `eslint-plugin-json-schema-validator` subfolder.
+  - `ttl` ... How long a cached schema is used before it is refetched. A number is milliseconds; a string is a duration such as `"30m"`, `"12h"`, `"1d"`, or `"2w"`. Defaults to 1 day. Use `0` to always refetch.
 
 #### Example of `http`
 
@@ -153,6 +160,25 @@ module.exports = {
           // Example of proxy settings.
           proxy: "http://my.proxy.com:8080/",
         },
+      },
+    },
+  },
+};
+```
+
+#### Example of `cache`
+
+Persist the cache to a directory that survives between runs (for example a mounted Docker volume), and refetch weekly:
+
+<!-- eslint-skip -->
+
+```js
+module.exports = {
+  settings: {
+    "json-schema-validator": {
+      cache: {
+        path: "/cache/eslint-json-schema-validator",
+        ttl: "1w",
       },
     },
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,10 @@ export type JsonSchemaValidatorSettings = {
     requestOptions?: any;
     getModulePath?: string;
   };
+  cache?: {
+    path?: string;
+    ttl?: number | string;
+  };
 };
 
 export interface RuleContext {

--- a/src/utils/cache-settings.ts
+++ b/src/utils/cache-settings.ts
@@ -2,6 +2,7 @@ import os from "os";
 import path from "path";
 
 import * as meta from "../meta.ts";
+import type { RuleContext } from "../types.ts";
 
 /** Default cache TTL: 1 day. */
 export const DEFAULT_TTL = 1000 * 60 * 60 * 24;
@@ -92,4 +93,21 @@ export function resolveCacheDir(
       : path.resolve(cwd, pathSetting);
   }
   return path.join(osCacheBaseDir(deps), meta.name);
+}
+
+/**
+ * Resolve the cache directory and TTL for a rule context.
+ * @param context - The ESLint rule context, whose `settings["json-schema-validator"].cache`
+ * (if present) supplies the raw `path` and `ttl` values.
+ * @returns The resolved absolute cache directory and TTL in milliseconds.
+ */
+export function getCacheSettings(context: RuleContext): {
+  cacheDir: string;
+  ttl: number;
+} {
+  const cache = context.settings?.["json-schema-validator"]?.cache;
+  return {
+    cacheDir: resolveCacheDir(cache?.path, context.cwd),
+    ttl: parseTtl(cache?.ttl),
+  };
 }

--- a/src/utils/cache-settings.ts
+++ b/src/utils/cache-settings.ts
@@ -18,6 +18,8 @@ const UNIT_MS: Record<string, number> = {
  * Parse a `cache.ttl` setting into milliseconds.
  * Accepts a non-negative millisecond number, or a duration string such as
  * "30m", "12h", "1d", "2w" (case-insensitive, surrounding whitespace allowed).
+ * A bare number string (e.g. "0", "1500") with no unit is treated as raw
+ * milliseconds.
  * @param value - The raw `cache.ttl` setting value, or `undefined`.
  * @returns The resolved TTL in milliseconds.
  * @throws {Error} If `value` is a negative number or an unrecognized string.
@@ -34,13 +36,15 @@ export function parseTtl(value: number | string | undefined): number {
     }
     return value;
   }
-  const match = /^\s*(\d+(?:\.\d+)?)\s*([dhmw])\s*$/iu.exec(value);
+  const match = /^\s*(\d+(?:\.\d+)?)(?:\s*([dhmw]))?\s*$/iu.exec(value);
   if (!match) {
     throw new Error(
       `Invalid cache.ttl: "${value}". Expected a number of milliseconds or a duration like "30m", "12h", "1d", "2w".`,
     );
   }
-  return Number(match[1]) * UNIT_MS[match[2].toLowerCase()];
+  const unit = match[2];
+  const multiplier = unit ? UNIT_MS[unit.toLowerCase()] : 1;
+  return Number(match[1]) * multiplier;
 }
 
 /** Injectable platform dependencies, used to make `resolveCacheDir` testable across OSes. */

--- a/src/utils/cache-settings.ts
+++ b/src/utils/cache-settings.ts
@@ -1,7 +1,6 @@
-import os from "os";
-import path from "path";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
 
-import * as meta from "../meta.ts";
 import type { RuleContext } from "../types.ts";
 
 /** Default cache TTL: 1 day. */
@@ -47,56 +46,34 @@ export function parseTtl(value: number | string | undefined): number {
   return Number(match[1]) * multiplier;
 }
 
-/** Injectable platform dependencies, used to make `resolveCacheDir` testable across OSes. */
-export interface PlatformDeps {
-  platform?: NodeJS.Platform;
-  env?: NodeJS.ProcessEnv;
-  homedir?: () => string;
-}
-
 /**
- * Resolve the OS user cache base directory.
- * @param deps - Injectable platform dependencies (platform, env, homedir).
- * @returns The OS-specific base directory under which per-app cache
- * directories are conventionally stored.
+ * The default cache directory, located alongside the built module.
+ * This is the historical location and is left unchanged; configuring
+ * `cache.path` is the supported way to move it.
  */
-function osCacheBaseDir({
-  platform = process.platform,
-  // eslint-disable-next-line no-process-env -- default only used when no deps are injected (e.g. real usage, not tests)
-  env = process.env,
-  homedir = os.homedir,
-}: PlatformDeps = {}): string {
-  const home = homedir();
-  if (platform === "win32") {
-    return env.LOCALAPPDATA || path.join(home, "AppData", "Local");
-  }
-  if (platform === "darwin") {
-    return path.join(home, "Library", "Caches");
-  }
-  return env.XDG_CACHE_HOME || path.join(home, ".cache");
-}
+export const DEFAULT_CACHE_DIR = path.join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../.cached_schemastore",
+);
 
 /**
  * Resolve the cache directory from a `cache.path` setting.
  * Absolute paths are used as-is; relative paths resolve against `cwd`; when
- * unset, the OS user cache directory under the plugin name is used.
+ * unset, the default cache directory alongside the module is used.
  * @param pathSetting - The raw `cache.path` setting value, or `undefined`.
  * @param cwd - The directory to resolve a relative `pathSetting` against.
- * @param deps - Injectable platform dependencies, used when `pathSetting` is
- * unset to determine the OS user cache directory.
  * @returns The resolved absolute cache directory path.
  */
 export function resolveCacheDir(
   pathSetting: string | undefined,
   cwd: string,
-  deps?: PlatformDeps,
 ): string {
   if (pathSetting) {
     return path.isAbsolute(pathSetting)
       ? pathSetting
       : path.resolve(cwd, pathSetting);
   }
-  return path.join(osCacheBaseDir(deps), meta.name);
+  return DEFAULT_CACHE_DIR;
 }
 
 /**

--- a/src/utils/cache-settings.ts
+++ b/src/utils/cache-settings.ts
@@ -1,0 +1,95 @@
+import os from "os";
+import path from "path";
+
+import * as meta from "../meta.ts";
+
+/** Default cache TTL: 1 day. */
+export const DEFAULT_TTL = 1000 * 60 * 60 * 24;
+
+const UNIT_MS: Record<string, number> = {
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  w: 7 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Parse a `cache.ttl` setting into milliseconds.
+ * Accepts a non-negative millisecond number, or a duration string such as
+ * "30m", "12h", "1d", "2w" (case-insensitive, surrounding whitespace allowed).
+ * @param value - The raw `cache.ttl` setting value, or `undefined`.
+ * @returns The resolved TTL in milliseconds.
+ * @throws {Error} If `value` is a negative number or an unrecognized string.
+ */
+export function parseTtl(value: number | string | undefined): number {
+  if (value == null) {
+    return DEFAULT_TTL;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(
+        `Invalid cache.ttl: ${value}. Expected a non-negative number of milliseconds.`,
+      );
+    }
+    return value;
+  }
+  const match = /^\s*(\d+(?:\.\d+)?)\s*([dhmw])\s*$/iu.exec(value);
+  if (!match) {
+    throw new Error(
+      `Invalid cache.ttl: "${value}". Expected a number of milliseconds or a duration like "30m", "12h", "1d", "2w".`,
+    );
+  }
+  return Number(match[1]) * UNIT_MS[match[2].toLowerCase()];
+}
+
+/** Injectable platform dependencies, used to make `resolveCacheDir` testable across OSes. */
+export interface PlatformDeps {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  homedir?: () => string;
+}
+
+/**
+ * Resolve the OS user cache base directory.
+ * @param deps - Injectable platform dependencies (platform, env, homedir).
+ * @returns The OS-specific base directory under which per-app cache
+ * directories are conventionally stored.
+ */
+function osCacheBaseDir({
+  platform = process.platform,
+  // eslint-disable-next-line no-process-env -- default only used when no deps are injected (e.g. real usage, not tests)
+  env = process.env,
+  homedir = os.homedir,
+}: PlatformDeps = {}): string {
+  const home = homedir();
+  if (platform === "win32") {
+    return env.LOCALAPPDATA || path.join(home, "AppData", "Local");
+  }
+  if (platform === "darwin") {
+    return path.join(home, "Library", "Caches");
+  }
+  return env.XDG_CACHE_HOME || path.join(home, ".cache");
+}
+
+/**
+ * Resolve the cache directory from a `cache.path` setting.
+ * Absolute paths are used as-is; relative paths resolve against `cwd`; when
+ * unset, the OS user cache directory under the plugin name is used.
+ * @param pathSetting - The raw `cache.path` setting value, or `undefined`.
+ * @param cwd - The directory to resolve a relative `pathSetting` against.
+ * @param deps - Injectable platform dependencies, used when `pathSetting` is
+ * unset to determine the OS user cache directory.
+ * @returns The resolved absolute cache directory path.
+ */
+export function resolveCacheDir(
+  pathSetting: string | undefined,
+  cwd: string,
+  deps?: PlatformDeps,
+): string {
+  if (pathSetting) {
+    return path.isAbsolute(pathSetting)
+      ? pathSetting
+      : path.resolve(cwd, pathSetting);
+  }
+  return path.join(osCacheBaseDir(deps), meta.name);
+}

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,18 +1,18 @@
 import debugBuilder from "debug";
 import fs from "fs";
 import { draft7 as migrateToDraft7 } from "json-schema-migrate-x";
-import path, { dirname } from "path";
-import { fileURLToPath } from "url";
+import path from "path";
 
 import type { RuleContext } from "../types.ts";
 import { get, syncGet } from "./http-client/index.ts";
 import type { SchemaObject } from "./types.ts";
 import * as meta from "../meta.ts";
+import { getCacheSettings } from "./cache-settings.ts";
 
 const debug = debugBuilder("eslint-plugin-json-schema-validator:utils-schema");
 
-const TTL = 1000 * 60 * 60 * 24; // 1 day
 const RELOADING = new Set<string>();
+const MEMORY_CACHE = new Map<string, { data: unknown; timestamp: number }>();
 
 /**
  * Load schema data
@@ -130,10 +130,8 @@ function loadJsonFromURL<T>(
   if (!jsonFileName.endsWith(".json")) {
     jsonFileName = `${jsonFileName}.json`;
   }
-  const jsonFilePath = path.join(
-    dirname(fileURLToPath(import.meta.url)),
-    `../.cached_schemastore/${jsonFileName}`,
-  );
+  const { cacheDir, ttl } = getCacheSettings(context);
+  const jsonFilePath = path.join(cacheDir, jsonFileName);
 
   const options = context.settings?.["json-schema-validator"]?.http;
 
@@ -143,28 +141,24 @@ function loadJsonFromURL<T>(
   fs.mkdirSync(path.dirname(jsonFilePath), { recursive: true });
 
   let data, timestamp;
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- Resolved by tsdown
-    ({ data, timestamp } = require(
-      `../.cached_schemastore/${jsonFileName}`,
-    ) as {
-      data: SchemaObject;
-      timestamp: number;
-    });
-  } catch {
+  const cached = MEMORY_CACHE.get(jsonFilePath);
+  if (cached) {
+    ({ data, timestamp } = cached);
+  } else {
     try {
       const jsonText = fs.readFileSync(jsonFilePath, "utf-8");
       ({ data, timestamp } = JSON.parse(jsonText) as {
         data: SchemaObject;
         timestamp: number;
       });
+      MEMORY_CACHE.set(jsonFilePath, { data, timestamp });
     } catch {
       // ignore
     }
   }
 
   if (data != null && typeof timestamp === "number") {
-    if (timestamp + TTL < Date.now()) {
+    if (timestamp + ttl < Date.now()) {
       // Reload!
       // However, the data can actually be used the next time access it.
       if (!RELOADING.has(jsonFilePath)) {
@@ -184,10 +178,6 @@ function loadJsonFromURL<T>(
     json = syncGet(jsonPath, httpRequestOptions, httpGetModulePath);
   } catch (e) {
     debug((e as Error).message);
-    // context.report({
-    //     loc: { line: 1, column: 0 },
-    //     message: `Could not be resolved: "${schemaPath}"`,
-    // })
     return null;
   }
 
@@ -219,15 +209,16 @@ function postProcess<T>(
     data = edit(data);
   }
 
+  const timestamp = Date.now();
   fs.writeFileSync(
     jsonFilePath,
     schemaStringify({
       data,
-      timestamp: Date.now(),
+      timestamp,
       v: meta.version,
     }),
   );
-  if (typeof require !== "undefined") delete require.cache[jsonFilePath];
+  MEMORY_CACHE.set(jsonFilePath, { data, timestamp });
 
   return data;
 }

--- a/tests/src/utils/cache-settings.ts
+++ b/tests/src/utils/cache-settings.ts
@@ -1,13 +1,13 @@
 import assert from "assert";
 import path from "path";
 import {
+  DEFAULT_CACHE_DIR,
   DEFAULT_TTL,
   parseTtl,
   resolveCacheDir,
   getCacheSettings,
 } from "../../../src/utils/cache-settings.ts";
 import type { RuleContext } from "../../../src/types.ts";
-import * as meta from "../../../src/meta.ts";
 
 describe("parseTtl", () => {
   it("returns the default TTL when unset", () => {
@@ -50,43 +50,12 @@ describe("resolveCacheDir", () => {
       path.resolve("/project", ".cache/schemastore"),
     );
   });
-  it("uses XDG_CACHE_HOME on linux when unset", () => {
-    const dir = resolveCacheDir(undefined, "/project", {
-      platform: "linux",
-      env: { XDG_CACHE_HOME: "/xdg" },
-      homedir: () => "/home/me",
-    });
-    assert.strictEqual(dir, path.join("/xdg", meta.name));
-  });
-  it("falls back to ~/.cache on linux without XDG_CACHE_HOME", () => {
-    const dir = resolveCacheDir(undefined, "/project", {
-      platform: "linux",
-      env: {},
-      homedir: () => "/home/me",
-    });
-    assert.strictEqual(dir, path.join("/home/me", ".cache", meta.name));
-  });
-  it("uses ~/Library/Caches on darwin", () => {
-    const dir = resolveCacheDir(undefined, "/project", {
-      platform: "darwin",
-      env: {},
-      homedir: () => "/Users/me",
-    });
+  it("uses the default cache directory when unset", () => {
     assert.strictEqual(
-      dir,
-      path.join("/Users/me", "Library", "Caches", meta.name),
+      resolveCacheDir(undefined, "/project"),
+      DEFAULT_CACHE_DIR,
     );
-  });
-  it("uses LOCALAPPDATA on win32", () => {
-    const dir = resolveCacheDir(undefined, "/project", {
-      platform: "win32",
-      env: { LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local" },
-      homedir: () => "C:\\Users\\me",
-    });
-    assert.strictEqual(
-      dir,
-      path.join("C:\\Users\\me\\AppData\\Local", meta.name),
-    );
+    assert.ok(DEFAULT_CACHE_DIR.endsWith(".cached_schemastore"));
   });
 });
 
@@ -111,6 +80,6 @@ describe("getCacheSettings", () => {
     } as unknown as RuleContext;
     const result = getCacheSettings(context);
     assert.strictEqual(result.ttl, DEFAULT_TTL);
-    assert.ok(result.cacheDir.includes(meta.name));
+    assert.strictEqual(result.cacheDir, DEFAULT_CACHE_DIR);
   });
 });

--- a/tests/src/utils/cache-settings.ts
+++ b/tests/src/utils/cache-settings.ts
@@ -1,0 +1,85 @@
+import assert from "assert";
+import path from "path";
+import {
+  DEFAULT_TTL,
+  parseTtl,
+  resolveCacheDir,
+} from "../../../src/utils/cache-settings.ts";
+import * as meta from "../../../src/meta.ts";
+
+describe("parseTtl", () => {
+  it("returns the default TTL when unset", () => {
+    assert.strictEqual(parseTtl(undefined), DEFAULT_TTL);
+  });
+  it("passes a non-negative number through as milliseconds", () => {
+    assert.strictEqual(parseTtl(0), 0);
+    assert.strictEqual(parseTtl(1500), 1500);
+  });
+  it("parses duration strings", () => {
+    assert.strictEqual(parseTtl("30m"), 30 * 60 * 1000);
+    assert.strictEqual(parseTtl("12h"), 12 * 60 * 60 * 1000);
+    assert.strictEqual(parseTtl("1d"), 24 * 60 * 60 * 1000);
+    assert.strictEqual(parseTtl("2w"), 2 * 7 * 24 * 60 * 60 * 1000);
+  });
+  it("tolerates whitespace and case", () => {
+    assert.strictEqual(parseTtl(" 12 H "), 12 * 60 * 60 * 1000);
+  });
+  it("throws on an unrecognized string", () => {
+    assert.throws(() => parseTtl("5x"), /Invalid cache\.ttl/u);
+    assert.throws(() => parseTtl("abc"), /Invalid cache\.ttl/u);
+  });
+  it("throws on a negative number", () => {
+    assert.throws(() => parseTtl(-1), /Invalid cache\.ttl/u);
+  });
+});
+
+describe("resolveCacheDir", () => {
+  it("returns an absolute path unchanged", () => {
+    const abs = path.resolve("/data/cache");
+    assert.strictEqual(resolveCacheDir(abs, "/project"), abs);
+  });
+  it("resolves a relative path against cwd", () => {
+    assert.strictEqual(
+      resolveCacheDir(".cache/schemastore", "/project"),
+      path.resolve("/project", ".cache/schemastore"),
+    );
+  });
+  it("uses XDG_CACHE_HOME on linux when unset", () => {
+    const dir = resolveCacheDir(undefined, "/project", {
+      platform: "linux",
+      env: { XDG_CACHE_HOME: "/xdg" },
+      homedir: () => "/home/me",
+    });
+    assert.strictEqual(dir, path.join("/xdg", meta.name));
+  });
+  it("falls back to ~/.cache on linux without XDG_CACHE_HOME", () => {
+    const dir = resolveCacheDir(undefined, "/project", {
+      platform: "linux",
+      env: {},
+      homedir: () => "/home/me",
+    });
+    assert.strictEqual(dir, path.join("/home/me", ".cache", meta.name));
+  });
+  it("uses ~/Library/Caches on darwin", () => {
+    const dir = resolveCacheDir(undefined, "/project", {
+      platform: "darwin",
+      env: {},
+      homedir: () => "/Users/me",
+    });
+    assert.strictEqual(
+      dir,
+      path.join("/Users/me", "Library", "Caches", meta.name),
+    );
+  });
+  it("uses LOCALAPPDATA on win32", () => {
+    const dir = resolveCacheDir(undefined, "/project", {
+      platform: "win32",
+      env: { LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local" },
+      homedir: () => "C:\\Users\\me",
+    });
+    assert.strictEqual(
+      dir,
+      path.join("C:\\Users\\me\\AppData\\Local", meta.name),
+    );
+  });
+});

--- a/tests/src/utils/cache-settings.ts
+++ b/tests/src/utils/cache-settings.ts
@@ -26,6 +26,10 @@ describe("parseTtl", () => {
   it("tolerates whitespace and case", () => {
     assert.strictEqual(parseTtl(" 12 H "), 12 * 60 * 60 * 1000);
   });
+  it("treats a bare-number string as raw milliseconds", () => {
+    assert.strictEqual(parseTtl("0"), 0);
+    assert.strictEqual(parseTtl("1500"), 1500);
+  });
   it("throws on an unrecognized string", () => {
     assert.throws(() => parseTtl("5x"), /Invalid cache\.ttl/u);
     assert.throws(() => parseTtl("abc"), /Invalid cache\.ttl/u);

--- a/tests/src/utils/cache-settings.ts
+++ b/tests/src/utils/cache-settings.ts
@@ -4,7 +4,9 @@ import {
   DEFAULT_TTL,
   parseTtl,
   resolveCacheDir,
+  getCacheSettings,
 } from "../../../src/utils/cache-settings.ts";
+import type { RuleContext } from "../../../src/types.ts";
 import * as meta from "../../../src/meta.ts";
 
 describe("parseTtl", () => {
@@ -81,5 +83,30 @@ describe("resolveCacheDir", () => {
       dir,
       path.join("C:\\Users\\me\\AppData\\Local", meta.name),
     );
+  });
+});
+
+describe("getCacheSettings", () => {
+  it("resolves cacheDir and ttl from settings", () => {
+    const context = {
+      settings: {
+        "json-schema-validator": {
+          cache: { path: "/abs/cache", ttl: "1d" },
+        },
+      },
+      cwd: "/project",
+    } as unknown as RuleContext;
+    const result = getCacheSettings(context);
+    assert.strictEqual(result.cacheDir, "/abs/cache");
+    assert.strictEqual(result.ttl, 24 * 60 * 60 * 1000);
+  });
+  it("falls back to defaults when cache settings are absent", () => {
+    const context = {
+      settings: {},
+      cwd: "/project",
+    } as unknown as RuleContext;
+    const result = getCacheSettings(context);
+    assert.strictEqual(result.ttl, DEFAULT_TTL);
+    assert.ok(result.cacheDir.includes(meta.name));
   });
 });

--- a/tests/src/utils/schema-cache.ts
+++ b/tests/src/utils/schema-cache.ts
@@ -1,0 +1,31 @@
+import assert from "assert";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { loadJson } from "../../../src/utils/schema.ts";
+import type { RuleContext } from "../../../src/types.ts";
+
+describe("schema cache location", () => {
+  it("reads a cached schema from the configured cache.path without fetching", () => {
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "jsv-cache-"));
+    const url = "http://cache.test.local/my-schema";
+    const filePath = path.join(cacheDir, "cache.test.local", "my-schema.json");
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const expected = { type: "object", title: "cached" };
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ data: expected, timestamp: Date.now(), v: "test" }),
+    );
+
+    const context = {
+      settings: { "json-schema-validator": { cache: { path: cacheDir } } },
+      cwd: process.cwd(),
+      report() {
+        throw new Error("should not report / fetch");
+      },
+    } as unknown as RuleContext;
+
+    const result = loadJson<typeof expected>(url, context);
+    assert.deepStrictEqual(result, expected);
+  });
+});


### PR DESCRIPTION
Closes #180

## Summary

Adds configuration for the schemastore HTTP cache used by `json-schema-validator/no-invalid`, and moves the default cache out of `node_modules` into the OS user cache directory so it persists across runs/projects by default, including in Docker & CI (previously cleared by `npm ci`).

## New settings

```js
settings: {
  "json-schema-validator": {
    cache: {
      path: "/cache/schemastore", // optional
      ttl: "1w",                  // optional
    },
  },
}
```

- **`path`** — where cached schemas are stored. A relative path resolves against the current working directory; an absolute path is used as-is. When unset, the OS user cache directory is used (`$XDG_CACHE_HOME`/`~/.cache`, `~/Library/Caches`, or `%LOCALAPPDATA%`) under an `eslint-plugin-json-schema-validator` subfolder.
- **`ttl`** — how long a cached schema is reused before refetch. Accepts a millisecond number or a duration string (`"30m"`, `"12h"`, `"1d"`, `"2w"`);  `0` (or `"0"`) always re-fetches. Defaults to 1 day.

## Implementation notes

- Switched from using `require` to cache files across a run to using a module-level `Map`.

## Compatibility

Should be fully backward-compatible (assuming the runtime context has a home directory for the active user). Existing configs keep the 1-day TTL. Due to the change in default cache location, this will require a one-time cache refresh. But since the default TTL is so low anyway, this is hardly an issue.

----

Pipeline will continue to fail until the merge of https://github.com/ota-meshi/eslint-plugin-json-schema-validator/pull/503.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable schema cache settings, including cache location and refresh interval.
  * Cache storage now uses a persistent default location, helping cached schemas survive across runs.

* **Bug Fixes**
  * Improved cache loading so previously stored schemas can be reused reliably.
  * Refetch timing now supports both numeric values and readable duration formats, with validation for invalid values.

* **Documentation**
  * Updated the user guide and README with cache configuration examples and reference details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->