### PR TITLE
Add opt-in `mostSpecificErrorsOnly` option to `no-invalid`

### DIFF
--- a/.changeset/most-specific-errors.md
+++ b/.changeset/most-specific-errors.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-json-schema-validator": minor
+---
+
+feat(no-invalid): add `mostSpecificErrorsOnly` option to collapse cascading `oneOf`/`anyOf` errors

--- a/docs/rules/no-invalid.md
+++ b/docs/rules/no-invalid.md
@@ -54,6 +54,7 @@ This rule validates the file with JSON Schema and reports errors.
       ],
       useSchemastoreCatalog: true,
       mergeSchemas: true, // or ["$schema", "options", "catalog"]
+      mostSpecificErrorsOnly: true,
     },
   ],
 }
@@ -64,6 +65,7 @@ This rule validates the file with JSON Schema and reports errors.
   - `schema` ... An object that defines a JSON schema. Or the path of the JSON schema file or URL.
 - `useSchemastoreCatalog` ... If `true`, it will automatically configure some schemas defined in [https://www.schemastore.org/api/json/catalog.json](https://www.schemastore.org/api/json/catalog.json). Default `true`
 - `mergeSchemas` ... If `true`, it will merge all schemas defined in `schemas`, at the `$schema` field within files, and the catalogue. If an array is given, it will merge only schemas from the given sources. Default `false`
+- `mostSpecificErrorsOnly` ... If `true`, collapses cascading `oneOf`/`anyOf` errors: when every alternative fails the same way the duplicate/umbrella errors are removed, otherwise only the closest-matching alternative is reported (alongside a `must match one of the allowed schemas` message). Default `false`
 
 This option can also be given a JSON schema file or URL. This is useful for configuring with the `/* eslint */` directive comments.
 

--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -42,12 +42,13 @@ function matchFile(filename: string, fileMatch: string[]) {
 function schemaPathToValidator(
   schemaPath: string,
   context: RuleContext,
+  mostSpecificErrorsOnly: boolean,
 ): Validator | null {
   const schema = loadSchema(schemaPath, context);
   if (!schema) {
     return null;
   }
-  return compile(schema, schemaPath, context);
+  return compile(schema, schemaPath, context, mostSpecificErrorsOnly);
 }
 
 /**
@@ -56,12 +57,13 @@ function schemaPathToValidator(
 function schemaObjectToValidator(
   schema: SchemaObject | null,
   context: RuleContext,
+  mostSpecificErrorsOnly: boolean,
 ): Validator | null {
   if (!schema) {
     return null;
   }
   const schemaPath = context.cwd;
-  return compile(schema, schemaPath, context);
+  return compile(schema, schemaPath, context, mostSpecificErrorsOnly);
 }
 
 /**
@@ -134,7 +136,6 @@ export default createRule("no-invalid", {
                 },
               },
               useSchemastoreCatalog: { type: "boolean" },
-              mostSpecificErrorsOnly: { type: "boolean" },
               mergeSchemas: {
                 oneOf: [
                   { type: "boolean" },
@@ -149,6 +150,7 @@ export default createRule("no-invalid", {
                   },
                 ],
               },
+              mostSpecificErrorsOnly: { type: "boolean" },
             },
             additionalProperties: false,
           },
@@ -161,6 +163,8 @@ export default createRule("no-invalid", {
   create: toCompatCreate((context, { filename }) => {
     const sourceCode = context.sourceCode;
     const cwd = context.cwd;
+    const mostSpecificErrorsOnly =
+      context.options[0]?.mostSpecificErrorsOnly === true;
     const relativeFilename = filename.startsWith(cwd)
       ? path.relative(cwd, filename)
       : filename;
@@ -385,7 +389,11 @@ export default createRule("no-invalid", {
       const $schemaPath = findSchemaPath(sourceCode.ast);
       if (!$schemaPath) return null;
 
-      const validator = schemaPathToValidator($schemaPath, context);
+      const validator = schemaPathToValidator(
+        $schemaPath,
+        context,
+        mostSpecificErrorsOnly,
+      );
       if (!validator) {
         reportCannotResolvedPath($schemaPath, context);
         return null;
@@ -429,7 +437,11 @@ export default createRule("no-invalid", {
         if (!matchFile(relativeFilename, schemaData.fileMatch)) {
           continue;
         }
-        const validator = schemaPathToValidator(schemaData.url, context);
+        const validator = schemaPathToValidator(
+          schemaData.url,
+          context,
+          mostSpecificErrorsOnly,
+        );
         if (validator) validators.push(validator);
       }
       return validators.length ? validators : null;
@@ -442,7 +454,11 @@ export default createRule("no-invalid", {
     ): Validator[] | null {
       const option = context.options[0];
       if (typeof option === "string") {
-        const validator = schemaPathToValidator(option, context);
+        const validator = schemaPathToValidator(
+          option,
+          context,
+          mostSpecificErrorsOnly,
+        );
         return validator ? [validator] : null;
       }
 
@@ -457,14 +473,22 @@ export default createRule("no-invalid", {
         }
 
         if (typeof schemaData.schema === "string") {
-          const validator = schemaPathToValidator(schemaData.schema, context);
+          const validator = schemaPathToValidator(
+            schemaData.schema,
+            context,
+            mostSpecificErrorsOnly,
+          );
           if (validator) {
             validators.push(validator);
           } else {
             reportCannotResolvedPath(schemaData.schema, context);
           }
         } else {
-          const validator = schemaObjectToValidator(schemaData.schema, context);
+          const validator = schemaObjectToValidator(
+            schemaData.schema,
+            context,
+            mostSpecificErrorsOnly,
+          );
           if (validator) {
             validators.push(validator);
           } else {

--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -134,6 +134,7 @@ export default createRule("no-invalid", {
                 },
               },
               useSchemastoreCatalog: { type: "boolean" },
+              mostSpecificErrorsOnly: { type: "boolean" },
               mergeSchemas: {
                 oneOf: [
                   { type: "boolean" },

--- a/src/utils/reduce-errors.ts
+++ b/src/utils/reduce-errors.ts
@@ -1,0 +1,135 @@
+import type { ErrorObject } from "./ajv.ts";
+
+/**
+ * Reduce cascading `oneOf`/`anyOf` validation errors to the most specific set.
+ *
+ * - If every branch of a failed combining keyword produced the *same* errors,
+ *   drop the umbrella error and return the deduplicated shared errors.
+ * - Otherwise keep the umbrella error plus the single best-matching branch.
+ * - Errors outside any combining keyword are returned unchanged.
+ *
+ * Pure function over ajv's raw error list; never fabricates new error objects.
+ */
+export function reduceErrors(errors: ErrorObject[]): ErrorObject[] {
+  return resolve(errors);
+}
+
+/** `oneOf`/`anyOf` are the "umbrella" (combining) keywords we collapse. */
+function isCombining(error: ErrorObject): boolean {
+  return error.keyword === "oneOf" || error.keyword === "anyOf";
+}
+
+/** Whether `schemaPath` is a branch (descendant) of the umbrella at `umbrellaPath`. */
+function isBranchOf(schemaPath: string, umbrellaPath: string): boolean {
+  return schemaPath.startsWith(`${umbrellaPath}/`);
+}
+
+/** The branch index for a branch error under `umbrellaPath` (e.g. "0", "1"). */
+function branchIndexOf(schemaPath: string, umbrellaPath: string): string {
+  return schemaPath.slice(`${umbrellaPath}/`.length).split("/")[0];
+}
+
+/** Stable identity of an error, independent of which branch produced it. */
+function errorKey(error: ErrorObject): string {
+  return JSON.stringify([error.instancePath, error.keyword, error.params]);
+}
+
+/** Depth (segment count) of the deepest instance path in a list. */
+function maxDepth(errors: ErrorObject[]): number {
+  return errors.reduce((max, e) => {
+    const depth = e.instancePath ? e.instancePath.split("/").length : 0;
+    return depth > max ? depth : max;
+  }, 0);
+}
+
+/**
+ * Resolve one level of `oneOf`/`anyOf` umbrellas within `errors`, recursing
+ * into each branch via {@link decide} to resolve any nested umbrellas first.
+ */
+function resolve(errors: ErrorObject[]): ErrorObject[] {
+  const umbrellas = errors.filter(isCombining);
+  // Outermost = umbrellas not nested inside another umbrella in this list.
+  const outermost = umbrellas.filter(
+    (u) =>
+      !umbrellas.some((o) => o !== u && isBranchOf(u.schemaPath, o.schemaPath)),
+  );
+  if (outermost.length === 0) {
+    return errors;
+  }
+
+  const result: ErrorObject[] = [];
+  for (const error of errors) {
+    if (outermost.includes(error)) {
+      const branchErrors = errors.filter(
+        (e) => e !== error && isBranchOf(e.schemaPath, error.schemaPath),
+      );
+      result.push(...decide(error, branchErrors));
+      continue;
+    }
+    // Skip errors that belong to any outermost umbrella (handled above).
+    if (outermost.some((u) => isBranchOf(error.schemaPath, u.schemaPath))) {
+      continue;
+    }
+    // Untouched error (not under any umbrella).
+    result.push(error);
+  }
+  return result;
+}
+
+/**
+ * Decide how to represent one umbrella error: drop it in favor of the shared
+ * errors when every branch resolves to the same error set, otherwise keep the
+ * umbrella plus the errors of the single best (deepest, then smallest,
+ * lowest-index) branch.
+ */
+function decide(
+  umbrella: ErrorObject,
+  branchErrors: ErrorObject[],
+): ErrorObject[] {
+  // Group by branch index, then resolve nested umbrellas within each branch.
+  const groups = new Map<string, ErrorObject[]>();
+  for (const e of branchErrors) {
+    const idx = branchIndexOf(e.schemaPath, umbrella.schemaPath);
+    const list = groups.get(idx);
+    if (list) list.push(e);
+    else groups.set(idx, [e]);
+  }
+  const resolved = [...groups.entries()]
+    .map(([idx, errs]) => ({ idx, errs: resolve(errs) }))
+    .filter((g) => g.errs.length > 0);
+
+  if (resolved.length === 0) {
+    // No usable branch information; keep the umbrella alone.
+    return [umbrella];
+  }
+
+  const keySets = resolved.map((g) => new Set(g.errs.map(errorKey)));
+  const sharedKeys = [...keySets[0]].filter((k) =>
+    keySets.every((s) => s.has(k)),
+  );
+  // Identical <=> no branch carries a key outside the shared set.
+  const allIdentical = keySets.every((s) => s.size === sharedKeys.length);
+
+  if (allIdentical) {
+    const seen = new Set<string>();
+    const deduped: ErrorObject[] = [];
+    for (const e of resolved[0].errs) {
+      const k = errorKey(e);
+      if (!seen.has(k)) {
+        seen.add(k);
+        deduped.push(e);
+      }
+    }
+    return deduped;
+  }
+
+  // Mismatch: keep the umbrella + the single best branch.
+  const best = [...resolved].sort((a, b) => {
+    const depthDiff = maxDepth(b.errs) - maxDepth(a.errs);
+    if (depthDiff !== 0) return depthDiff;
+    const countDiff = a.errs.length - b.errs.length;
+    if (countDiff !== 0) return countDiff;
+    return Number(a.idx) - Number(b.idx);
+  })[0];
+  return [umbrella, ...best.errs];
+}

--- a/src/utils/validator-factory.ts
+++ b/src/utils/validator-factory.ts
@@ -64,8 +64,9 @@ export function compile(
   schema: SchemaObject,
   schemaPath: string,
   context: RuleContext,
+  mostSpecificErrorsOnly: boolean,
 ): Validator {
-  return schemaToValidator(schema, schemaPath, context);
+  return schemaToValidator(schema, schemaPath, context, mostSpecificErrorsOnly);
 }
 
 /**
@@ -75,10 +76,9 @@ function schemaToValidator(
   schema: SchemaObject,
   schemaPath: string,
   context: RuleContext,
+  mostSpecific: boolean,
 ): Validator {
   let validateSchema: ValidateFunction;
-
-  const mostSpecific = context.options[0]?.mostSpecificErrorsOnly === true;
 
   let schemaObject = schema;
   while (true) {

--- a/src/utils/validator-factory.ts
+++ b/src/utils/validator-factory.ts
@@ -78,10 +78,7 @@ function schemaToValidator(
 ): Validator {
   let validateSchema: ValidateFunction;
 
-  const mostSpecific =
-    typeof context.options[0] === "object" &&
-    context.options[0] != null &&
-    context.options[0].mostSpecificErrorsOnly === true;
+  const mostSpecific = context.options[0]?.mostSpecificErrorsOnly === true;
 
   let schemaObject = schema;
   while (true) {

--- a/src/utils/validator-factory.ts
+++ b/src/utils/validator-factory.ts
@@ -9,6 +9,7 @@ import type {
   ValidateFunction,
 } from "./ajv.ts";
 import Ajv from "./ajv.ts";
+import { reduceErrors } from "./reduce-errors.ts";
 import { loadSchema } from "./schema.ts";
 import v6Schema from "ajv/lib/refs/json-schema-draft-06.json" with { type: "json" };
 
@@ -77,6 +78,11 @@ function schemaToValidator(
 ): Validator {
   let validateSchema: ValidateFunction;
 
+  const mostSpecific =
+    typeof context.options[0] === "object" &&
+    context.options[0] != null &&
+    context.options[0].mostSpecificErrorsOnly === true;
+
   let schemaObject = schema;
   while (true) {
     try {
@@ -114,8 +120,9 @@ function schemaToValidator(
     if (validateSchema(data)) {
       return [];
     }
-
-    return validateSchema.errors!.map(errorToValidateError);
+    const raw = validateSchema.errors!;
+    const reduced = mostSpecific ? reduceErrors(raw) : raw;
+    return reduced.map((error) => errorToValidateError(error, mostSpecific));
   };
 }
 
@@ -184,6 +191,7 @@ function resolveError(
 function errorToValidateError(
   /* eslint-enable complexity -- X( */
   errorObject: ErrorObject,
+  mostSpecific = false,
 ): ValidateError {
   const error: DefinedError = errorObject as DefinedError;
 
@@ -194,6 +202,16 @@ function errorToValidateError(
   const path: string[] = instancePath
     ? instancePath.split("/").map(unescapeFragment)
     : [];
+
+  if (
+    mostSpecific &&
+    (error.keyword === "oneOf" || error.keyword === "anyOf")
+  ) {
+    return {
+      message: `${joinPath(path)} must match one of the allowed schemas.`,
+      path,
+    };
+  }
 
   if (error.keyword === "additionalProperties") {
     path.push(error.params.additionalProperty);

--- a/tests/src/rules/no-invalid.ts
+++ b/tests/src/rules/no-invalid.ts
@@ -342,6 +342,91 @@ singleQuote = true`,
             "Root must match exactly one schema in oneOf.",
           ],
         },
+        // mostSpecificErrorsOnly: OFF (default) — cascade preserved
+        {
+          filename: "reduce-off.json",
+          code: '{ "extends": [ 42 ] }',
+          options: [
+            {
+              schemas: [
+                {
+                  fileMatch: ["reduce-off.json"],
+                  schema: {
+                    type: "object",
+                    properties: {
+                      extends: {
+                        oneOf: [
+                          { type: "string" },
+                          { type: "array", items: { type: "string" } },
+                        ],
+                      },
+                    },
+                  },
+                },
+              ],
+              useSchemastoreCatalog: false,
+            },
+          ],
+          errors: [
+            '"extends" must be string.',
+            '"extends" must match exactly one schema in oneOf.',
+            '"extends[0]" must be string.',
+          ],
+        },
+        // mostSpecificErrorsOnly: ON — best-branch + reworded umbrella
+        {
+          filename: "reduce-on.json",
+          code: '{ "extends": [ 42 ] }',
+          options: [
+            {
+              schemas: [
+                {
+                  fileMatch: ["reduce-on.json"],
+                  schema: {
+                    type: "object",
+                    properties: {
+                      extends: {
+                        oneOf: [
+                          { type: "string" },
+                          { type: "array", items: { type: "string" } },
+                        ],
+                      },
+                    },
+                  },
+                },
+              ],
+              useSchemastoreCatalog: false,
+              mostSpecificErrorsOnly: true,
+            },
+          ],
+          errors: [
+            '"extends" must match one of the allowed schemas.',
+            '"extends[0]" must be string.',
+          ],
+        },
+        // mostSpecificErrorsOnly: ON — identical branches collapse to one error
+        {
+          filename: "reduce-identical.json",
+          code: '"hello"',
+          options: [
+            {
+              schemas: [
+                {
+                  fileMatch: ["reduce-identical.json"],
+                  schema: {
+                    oneOf: [
+                      { type: "object", properties: { a: { type: "number" } } },
+                      { type: "object", properties: { b: { type: "number" } } },
+                    ],
+                  },
+                },
+              ],
+              useSchemastoreCatalog: false,
+              mostSpecificErrorsOnly: true,
+            },
+          ],
+          errors: ["Root must be object."],
+        },
       ],
     },
   ),

--- a/tests/src/rules/no-invalid.ts
+++ b/tests/src/rules/no-invalid.ts
@@ -427,6 +427,34 @@ singleQuote = true`,
           ],
           errors: ["Root must be object."],
         },
+        // mostSpecificErrorsOnly: ON — anyOf end-to-end: umbrella + best branch
+        {
+          filename: "reduce-anyof.json",
+          code: '{ "val": true }',
+          options: [
+            {
+              schemas: [
+                {
+                  fileMatch: ["reduce-anyof.json"],
+                  schema: {
+                    type: "object",
+                    properties: {
+                      val: {
+                        anyOf: [{ type: "string" }, { type: "number" }],
+                      },
+                    },
+                  },
+                },
+              ],
+              useSchemastoreCatalog: false,
+              mostSpecificErrorsOnly: true,
+            },
+          ],
+          errors: [
+            '"val" must match one of the allowed schemas.',
+            '"val" must be string.',
+          ],
+        },
         // mostSpecificErrorsOnly: ON — partial overlap (the issue's typo scenario):
         // both branches agree `runn` is unexpected but each requires a different
         // property, so the umbrella + best (lowest-index) branch are reported.

--- a/tests/src/rules/no-invalid.ts
+++ b/tests/src/rules/no-invalid.ts
@@ -427,6 +427,44 @@ singleQuote = true`,
           ],
           errors: ["Root must be object."],
         },
+        // mostSpecificErrorsOnly: ON — partial overlap (the issue's typo scenario):
+        // both branches agree `runn` is unexpected but each requires a different
+        // property, so the umbrella + best (lowest-index) branch are reported.
+        {
+          filename: "reduce-typo.json",
+          code: '{ "name": "t", "runn": "echo" }',
+          options: [
+            {
+              schemas: [
+                {
+                  fileMatch: ["reduce-typo.json"],
+                  schema: {
+                    type: "object",
+                    oneOf: [
+                      {
+                        required: ["run"],
+                        properties: { run: {}, name: {} },
+                        additionalProperties: false,
+                      },
+                      {
+                        required: ["uses"],
+                        properties: { uses: {}, name: {} },
+                        additionalProperties: false,
+                      },
+                    ],
+                  },
+                },
+              ],
+              useSchemastoreCatalog: false,
+              mostSpecificErrorsOnly: true,
+            },
+          ],
+          errors: [
+            "Root must match one of the allowed schemas.",
+            "Root must have required property 'run'.",
+            'Unexpected property "runn"',
+          ],
+        },
       ],
     },
   ),

--- a/tests/src/utils/reduce-errors.ts
+++ b/tests/src/utils/reduce-errors.ts
@@ -204,4 +204,150 @@ describe("reduceErrors", () => {
       { path: "", keyword: "type", params: { type: "number" } },
     ]);
   });
+
+  it("keeps umbrella + best branch when branches share some but not all errors", () => {
+    // Typo shape (the issue's motivating case): every branch reports the same
+    // `additionalProperties` error, but each also has a branch-specific `required`.
+    // Because the branches are NOT identical, this must NOT collapse to the shared
+    // error alone — it keeps the umbrella plus the single best branch (both branches
+    // tie on depth and count, so the lowest index, the `run` branch, wins).
+    const errors = errorsFor(
+      {
+        type: "object",
+        oneOf: [
+          {
+            required: ["run"],
+            properties: { run: {}, name: {} },
+            additionalProperties: false,
+          },
+          {
+            required: ["uses"],
+            properties: { uses: {}, name: {} },
+            additionalProperties: false,
+          },
+        ],
+      },
+      { name: "t", runn: "echo" },
+    );
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      {
+        path: "",
+        keyword: "additionalProperties",
+        params: { additionalProperty: "runn" },
+      },
+      { path: "", keyword: "oneOf", params: { passingSchemas: null } },
+      { path: "", keyword: "required", params: { missingProperty: "run" } },
+    ]);
+  });
+
+  it("reduces sibling umbrellas independently (neither nested in the other)", () => {
+    const errors = errorsFor(
+      {
+        type: "object",
+        properties: {
+          a: {
+            oneOf: [
+              { type: "string" },
+              { type: "array", items: { type: "string" } },
+            ],
+          },
+          b: { anyOf: [{ type: "boolean" }, { type: "number" }] },
+        },
+      },
+      { a: [42], b: "x" },
+    );
+    // `/a` keeps umbrella + deepest branch (`/a/0`); `/b` keeps umbrella + lowest-index
+    // branch (boolean). The two umbrellas are peers, reduced independently.
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      { path: "/a/0", keyword: "type", params: { type: "string" } },
+      { path: "/a", keyword: "oneOf", params: { passingSchemas: null } },
+      { path: "/b", keyword: "anyOf", params: {} },
+      { path: "/b", keyword: "type", params: { type: "boolean" } },
+    ]);
+  });
+
+  it("keeps every error of the winning branch (multi-error branch)", () => {
+    const errors = errorsFor(
+      {
+        oneOf: [
+          { type: "string" },
+          {
+            type: "object",
+            required: ["p", "q"],
+            properties: { p: { type: "number" }, q: { type: "number" } },
+          },
+        ],
+      },
+      { p: "x" },
+    );
+    // The object branch is deepest, so it wins; BOTH of its errors survive
+    // (`/p` type mismatch and the missing `q`), not just one.
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      { path: "/p", keyword: "type", params: { type: "number" } },
+      { path: "", keyword: "oneOf", params: { passingSchemas: null } },
+      { path: "", keyword: "required", params: { missingProperty: "q" } },
+    ]);
+  });
+
+  it("resolves three levels of nested oneOf innermost-first", () => {
+    const errors = errorsFor(
+      {
+        oneOf: [
+          { type: "string" },
+          {
+            type: "object",
+            required: ["x"],
+            properties: {
+              x: {
+                oneOf: [
+                  { type: "boolean" },
+                  {
+                    type: "object",
+                    required: ["y"],
+                    properties: {
+                      y: { oneOf: [{ type: "integer" }, { type: "string" }] },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      { x: { y: true } },
+    );
+    // At each level the umbrella + its deepest branch survive; every losing branch
+    // (string at root, boolean at `/x`, string at `/x/y`) is dropped.
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      { path: "/x/y", keyword: "oneOf", params: { passingSchemas: null } },
+      { path: "/x/y", keyword: "type", params: { type: "integer" } },
+      { path: "/x", keyword: "oneOf", params: { passingSchemas: null } },
+      { path: "", keyword: "oneOf", params: { passingSchemas: null } },
+    ]);
+  });
+
+  it("handles sibling umbrellas where one collapses and one keeps its best branch", () => {
+    const errors = errorsFor(
+      {
+        type: "object",
+        properties: {
+          a: { oneOf: [{ type: "object" }, { type: "object" }] },
+          b: {
+            oneOf: [
+              { type: "string" },
+              { type: "array", items: { type: "string" } },
+            ],
+          },
+        },
+      },
+      { a: "s", b: [42] },
+    );
+    // `/a` branches are identical -> collapse, umbrella dropped.
+    // `/b` branches differ -> umbrella + deepest branch kept.
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      { path: "/a", keyword: "type", params: { type: "object" } },
+      { path: "/b/0", keyword: "type", params: { type: "string" } },
+      { path: "/b", keyword: "oneOf", params: { passingSchemas: null } },
+    ]);
+  });
 });

--- a/tests/src/utils/reduce-errors.ts
+++ b/tests/src/utils/reduce-errors.ts
@@ -77,6 +77,24 @@ describe("reduceErrors", () => {
     ]);
   });
 
+  it("keeps the oneOf umbrella when multiple schemas pass (multi-match)", () => {
+    // Data matches BOTH branches, so ajv emits only the `oneOf` umbrella
+    // (passingSchemas: [0, 1]) with no branch errors. There is nothing to
+    // collapse into, so the "must match exactly one schema" cause survives.
+    const errors = errorsFor(
+      {
+        oneOf: [
+          { type: "object", properties: { a: { type: "number" } } },
+          { type: "object", properties: { b: { type: "number" } } },
+        ],
+      },
+      { a: 1, b: 2 },
+    );
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      { path: "", keyword: "oneOf", params: { passingSchemas: [0, 1] } },
+    ]);
+  });
+
   it("preserves errors outside the umbrella", () => {
     const errors = errorsFor(
       {

--- a/tests/src/utils/reduce-errors.ts
+++ b/tests/src/utils/reduce-errors.ts
@@ -1,0 +1,158 @@
+import assert from "assert";
+import Ajv from "ajv";
+import type { ErrorObject } from "../../../src/utils/ajv.ts";
+import { reduceErrors } from "../../../src/utils/reduce-errors.ts";
+
+function errorsFor(schema: object, data: unknown): ErrorObject[] {
+  const ajv = new Ajv({ allErrors: true, verbose: true, strict: false });
+  const validate = ajv.compile(schema);
+  validate(data);
+  return validate.errors ?? [];
+}
+
+/** Project errors to a stable, comparable shape and sort them. */
+function project(errors: ErrorObject[]) {
+  return errors
+    .map((e) => ({
+      path: e.instancePath,
+      keyword: e.keyword,
+      params: e.params,
+    }))
+    .sort((a, b) =>
+      `${a.path}|${a.keyword}|${JSON.stringify(a.params)}`.localeCompare(
+        `${b.path}|${b.keyword}|${JSON.stringify(b.params)}`,
+      ),
+    );
+}
+
+describe("reduceErrors", () => {
+  it("returns non-combining errors unchanged", () => {
+    const errors = errorsFor(
+      {
+        type: "object",
+        required: ["foo"],
+        properties: { bar: { type: "number" } },
+      },
+      { bar: "x" },
+    );
+    // Two independent errors: required 'foo' and type of bar. No oneOf/anyOf.
+    assert.deepStrictEqual(project(reduceErrors(errors)), project(errors));
+  });
+
+  it("collapses identical branch failures and drops the umbrella", () => {
+    // Value is a string; both branches require an object -> identical `type` errors.
+    const errors = errorsFor(
+      {
+        oneOf: [
+          { type: "object", properties: { a: { type: "number" } } },
+          { type: "object", properties: { b: { type: "number" } } },
+        ],
+      },
+      "hello",
+    );
+    const reduced = reduceErrors(errors);
+    assert.deepStrictEqual(project(reduced), [
+      { path: "", keyword: "type", params: { type: "object" } },
+    ]);
+  });
+
+  it("keeps umbrella + deepest branch when branches differ", () => {
+    const errors = errorsFor(
+      {
+        type: "object",
+        properties: {
+          extends: {
+            oneOf: [
+              { type: "string" },
+              { type: "array", items: { type: "string" } },
+            ],
+          },
+        },
+      },
+      { extends: [42] },
+    );
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      { path: "/extends/0", keyword: "type", params: { type: "string" } },
+      { path: "/extends", keyword: "oneOf", params: { passingSchemas: null } },
+    ]);
+  });
+
+  it("preserves errors outside the umbrella", () => {
+    const errors = errorsFor(
+      {
+        type: "object",
+        required: ["foo"],
+        properties: {
+          extends: {
+            oneOf: [
+              { type: "string" },
+              { type: "array", items: { type: "string" } },
+            ],
+          },
+        },
+      },
+      { extends: [42] },
+    );
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      { path: "/extends/0", keyword: "type", params: { type: "string" } },
+      { path: "/extends", keyword: "oneOf", params: { passingSchemas: null } },
+      { path: "", keyword: "required", params: { missingProperty: "foo" } },
+    ]);
+  });
+
+  it("breaks ties by lowest branch index (anyOf)", () => {
+    const errors = errorsFor(
+      {
+        type: "object",
+        properties: {
+          val: { anyOf: [{ type: "string" }, { type: "number" }] },
+        },
+      },
+      { val: true },
+    );
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      { path: "/val", keyword: "anyOf", params: {} },
+      { path: "/val", keyword: "type", params: { type: "string" } },
+    ]);
+  });
+
+  it("resolves nested oneOf inside a branch before the outer one", () => {
+    // Outer oneOf: branch0 wants a string; branch1 wants an object whose `x`
+    // is itself oneOf[boolean, number]. Data picks the object branch but `x`
+    // is a string, so the inner oneOf fails specifically.
+    const errors = errorsFor(
+      {
+        oneOf: [
+          { type: "string" },
+          {
+            type: "object",
+            properties: {
+              x: { oneOf: [{ type: "boolean" }, { type: "number" }] },
+            },
+            required: ["x"],
+          },
+        ],
+      },
+      { x: "nope" },
+    );
+    const reduced = project(reduceErrors(errors));
+    // Outer umbrella kept (object branch is deepest); inner umbrella kept with
+    // its best branch; the outer string-branch error is dropped.
+    assert.ok(
+      reduced.some((e) => e.path === "" && e.keyword === "oneOf"),
+      "outer umbrella kept",
+    );
+    assert.ok(
+      reduced.some((e) => e.path === "/x" && e.keyword === "oneOf"),
+      "inner umbrella kept",
+    );
+    assert.ok(
+      reduced.some((e) => e.path === "/x" && e.keyword === "type"),
+      "inner best-branch type error kept",
+    );
+    assert.ok(
+      !reduced.some((e) => e.path === "" && e.keyword === "type"),
+      "outer losing string-branch dropped",
+    );
+  });
+});

--- a/tests/src/utils/reduce-errors.ts
+++ b/tests/src/utils/reduce-errors.ts
@@ -155,4 +155,53 @@ describe("reduceErrors", () => {
       "outer losing string-branch dropped",
     );
   });
+
+  it("keeps the umbrella alone when no branch produced descendant errors", () => {
+    // Both branches pass, so ajv only emits the oneOf umbrella error
+    // (no per-branch descendant errors exist to reduce).
+    const errors = errorsFor(
+      { oneOf: [{ type: "object" }, { type: "object" }] },
+      { a: 1 },
+    );
+    assert.deepStrictEqual(project(reduceErrors(errors)), project(errors));
+    assert.deepStrictEqual(project(errors), [
+      {
+        path: "",
+        keyword: "oneOf",
+        params: { passingSchemas: [0, 1] },
+      },
+    ]);
+  });
+
+  it("handles 3+ branches (two identical + one differing)", () => {
+    const errors = errorsFor(
+      {
+        type: "object",
+        properties: {
+          v: {
+            anyOf: [
+              { type: "number" },
+              { type: "number" },
+              { type: "boolean" },
+            ],
+          },
+        },
+      },
+      { v: "str" },
+    );
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      { path: "/v", keyword: "anyOf", params: {} },
+      { path: "/v", keyword: "type", params: { type: "number" } },
+    ]);
+  });
+
+  it("collapses 3 identical branch failures and drops the umbrella", () => {
+    const errors = errorsFor(
+      { anyOf: [{ type: "number" }, { type: "number" }, { type: "number" }] },
+      "str",
+    );
+    assert.deepStrictEqual(project(reduceErrors(errors)), [
+      { path: "", keyword: "type", params: { type: "number" } },
+    ]);
+  });
 });


### PR DESCRIPTION
Closes #278

## Summary

When a value fails a schema that uses `oneOf`/`anyOf`, ajv (run with `allErrors`) reports a cascade of errors for one root cause: the combining ("umbrella") error, every losing branch, and the specific leaf error. This work adds an opt-in option to collapse that noise down to the most specific, non-misleading errors.

## New Option on `no-invalid`

```jsonc
{
  "json-schema-validator/no-invalid": ["error", { "mostSpecificErrorsOnly": true }]
}
```

**Behavior** — for each failed `oneOf`/`anyOf`:
- If **every** alternative failed identically, the duplicate errors are deduplicated and the umbrella error is dropped.
- Otherwise, only the **closest-matching** alternative is reported (deepest match; ties broken by fewest errors, then lowest branch index), alongside a reworded `… must match one of the allowed schemas.` message. The specific branch guesses of the *other* alternatives are suppressed.
- Errors outside any combining keyword (e.g. an unrelated missing `required` property) are never touched.

### Examples

#### Fully Shared

**Case:** `{ "name": 42 } where the schema is oneOf: [ {…, name: string}, {…, name: string} ]`

```txt
# (Current) `mostSpecificErrorsOnly: false`
"name" must be string.
"name" must be string.
Root must match exactly one schema in oneOf.

# (Added) `mostSpecificErrorsOnly: true`
"name" must be string.
```

#### Best Match

**Case:** `{ "extends": [42] }` where `extends` is `oneOf: [string, string[]]`:

```txt
# (Current) `mostSpecificErrorsOnly: false`
"extends" must be string.
"extends" must match exactly one schema in oneOf.
"extends[0]" must be string.

# (Added) `mostSpecificErrorsOnly: true`
"extends" must match one of the allowed schemas.
"extends[0]" must be string.
```

## Compatibility

No user-facing changes. All behavioral changes lie behind the new option, which remains defaulting to `false`. 

----

Pipeline will continue to fail until the merge of https://github.com/ota-meshi/eslint-plugin-json-schema-validator/pull/503.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional error-reporting mode that shows the most specific validation errors when available.
  * Improved validation messages to better summarize `oneOf`/`anyOf` schema mismatches.

* **Bug Fixes**
  * Reduced cascading duplicate errors so validation output is cleaner and easier to understand.

* **Documentation**
  * Updated the rule guide with the new configuration option and its default behavior.

* **Tests**
  * Expanded coverage for the new error-reduction behavior across multiple validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->