### PR TITLE
feat: add support for validating markdown frontmatter

### DIFF
--- a/.changeset/quiet-lines-drum.md
+++ b/.changeset/quiet-lines-drum.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-json-schema-validator": minor
+---
+
+feat: add support for validating markdown frontmatter

--- a/docs/rules/no-invalid.md
+++ b/docs/rules/no-invalid.md
@@ -170,6 +170,53 @@ foo: bar
 </i18n>
 ```
 
+### Validate Markdown frontmatter
+
+This rule can validate the [front matter](https://github.com/eslint/markdown/blob/main/docs/language-options.md) of Markdown files.
+
+You must install [`@eslint/markdown`](https://github.com/eslint/markdown) and enable front matter parsing via `languageOptions.frontmatter` (`"yaml"`, `"toml"`, or `"json"`). This rule then validates the parsed front matter against the schema you configure for the Markdown file.
+
+```js
+import eslintPluginJsonSchemaValidator from "eslint-plugin-json-schema-validator";
+import markdown from "@eslint/markdown";
+
+export default [
+  ...eslintPluginJsonSchemaValidator.configs.recommended,
+  {
+    files: ["**/*.md"],
+    plugins: { markdown },
+    language: "markdown/commonmark",
+    languageOptions: { frontmatter: "yaml" },
+    rules: {
+      "json-schema-validator/no-invalid": [
+        "error",
+        {
+          schemas: [
+            {
+              fileMatch: ["**/*.md"],
+              schema: { type: "object" /* JSON Schema Definition */ },
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+For example, the following front matter would be validated against the schema above:
+
+<!-- eslint-skip -->
+
+```md
+---
+title: My Post
+draft: false
+---
+
+# My Post
+```
+
 ## :books: Further reading
 
 - [JSON Schema](https://json-schema.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,13 @@
 {
   "name": "eslint-plugin-json-schema-validator",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "dev": true,
   "packages": {
     "": {
       "name": "eslint-plugin-json-schema-validator",
-      "version": "6.2.0",
-      "dev": true,
+      "version": "6.3.0",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.3.0",
@@ -31,6 +30,7 @@
         "@eslint-community/eslint-plugin-eslint-comments": "^4.0.0",
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^10.0.0",
+        "@eslint/markdown": "^8.0.0",
         "@ota-meshi/eslint-plugin": "^0.20.0",
         "@oxc-node/core": "^0.1.0",
         "@shikijs/vitepress-twoslash": "^4.0.0",
@@ -90,7 +90,13 @@
         "url": "https://github.com/sponsors/ota-meshi"
       },
       "peerDependencies": {
+        "@eslint/markdown": ">=8.0.0",
         "eslint": ">=9.38.0"
+      },
+      "peerDependenciesMeta": {
+        "@eslint/markdown": {
+          "optional": true
+        }
       }
     },
     "node_modules/@actions/core": {
@@ -1680,9 +1686,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1813,6 +1819,46 @@
         "eslint": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@eslint/markdown": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.3.tgz",
+      "integrity": "sha512-rBTSSShrq7e4O+PWfeE4azH4/CWPNrC+VGxBXiW00o3vYVJnznsZiDayj3KC9JztIMVRZxZHn2nrDIUau/4j7A==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "github-slugger": "^2.0.0",
+        "mdast-util-from-markdown": "^2.0.2",
+        "mdast-util-frontmatter": "^2.0.1",
+        "mdast-util-gfm": "^3.1.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "micromark-extension-math": "^3.1.0",
+        "micromark-util-normalize-identifier": "^2.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/markdown/node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -2386,9 +2432,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2403,9 +2446,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2420,9 +2460,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2437,9 +2474,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2454,9 +2488,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2471,9 +2502,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3651,6 +3679,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6813,6 +6848,20 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -6977,6 +7026,15 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -7108,6 +7166,13 @@
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -8116,6 +8181,33 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8411,6 +8503,38 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-gfm": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
@@ -8512,6 +8636,26 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8697,6 +8841,171 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -12326,6 +12635,21 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,13 @@
     "version:ci": "env-cmd -e version-ci -- npm run update && changeset version"
   },
   "peerDependencies": {
+    "@eslint/markdown": ">=8.0.0",
     "eslint": ">=9.38.0"
+  },
+  "peerDependenciesMeta": {
+    "@eslint/markdown": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.3.0",
@@ -79,6 +85,7 @@
     "@eslint-community/eslint-plugin-eslint-comments": "^4.0.0",
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^10.0.0",
+    "@eslint/markdown": "^8.0.0",
     "@ota-meshi/eslint-plugin": "^0.20.0",
     "@oxc-node/core": "^0.1.0",
     "@shikijs/vitepress-twoslash": "^4.0.0",

--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -1,9 +1,13 @@
+import { SourceCode } from "eslint";
 import type { AST as JSONAST } from "jsonc-eslint-parser";
 import { getStaticJSONValue } from "jsonc-eslint-parser";
+import * as jsoncESLintParser from "jsonc-eslint-parser";
 import type { AST as YAML } from "yaml-eslint-parser";
 import { getStaticYAMLValue } from "yaml-eslint-parser";
+import * as yamlESLintParser from "yaml-eslint-parser";
 import type { AST as TOML } from "toml-eslint-parser";
 import { getStaticTOMLValue } from "toml-eslint-parser";
+import * as tomlESLintParser from "toml-eslint-parser";
 import { createRule } from "../utils/index.ts";
 import { minimatch } from "minimatch";
 import path from "path";
@@ -33,6 +37,47 @@ const CATALOG_URL = "https://www.schemastore.org/api/json/catalog.json";
  * schema path.
  */
 const SCHEMA_NONE = Symbol("$schema=none");
+
+/** A `@eslint/markdown` frontmatter node (mdast `Literal`). */
+interface MarkdownFrontmatterNode {
+  type: "yaml" | "toml" | "json";
+  value: string;
+  position: { start: { offset: number } };
+}
+
+interface FrontmatterHandler {
+  parse: (code: string) => { ast: unknown };
+  getStaticValue: (ast: unknown) => unknown;
+  getNodeFromPath: (
+    ast: unknown,
+    paths: string[],
+  ) => NodeData<JSONAST.JSONNode | YAML.YAMLNode | TOML.TOMLNode>;
+}
+
+/** Frontmatter handlers keyed by the mdast frontmatter node type. */
+const FRONTMATTER_HANDLERS: Record<
+  MarkdownFrontmatterNode["type"],
+  FrontmatterHandler
+> = {
+  yaml: {
+    parse: (code) => yamlESLintParser.parseForESLint(code),
+    getStaticValue: (ast) => getStaticYAMLValue(ast as YAML.YAMLProgram),
+    getNodeFromPath: (ast, paths) =>
+      getYAMLNodeFromPath(ast as YAML.YAMLProgram, paths),
+  },
+  toml: {
+    parse: (code) => tomlESLintParser.parseForESLint(code),
+    getStaticValue: (ast) => getStaticTOMLValue(ast as TOML.TOMLProgram),
+    getNodeFromPath: (ast, paths) =>
+      getTOMLNodeFromPath(ast as TOML.TOMLProgram, paths),
+  },
+  json: {
+    parse: (code) => jsoncESLintParser.parseForESLint(code),
+    getStaticValue: (ast) => getStaticJSONValue(ast as JSONAST.JSONProgram),
+    getNodeFromPath: (ast, paths) =>
+      getJSONNodeFromPath(ast as JSONAST.JSONProgram, paths),
+  },
+};
 
 /**
  * Checks if match file
@@ -242,6 +287,52 @@ export default createRule("no-invalid", {
       });
     }
 
+    /** Validate a Markdown frontmatter node against the schema. */
+    function validateFrontmatter(
+      node: MarkdownFrontmatterNode,
+      handler: FrontmatterHandler,
+    ) {
+      let parsed: { ast: unknown };
+      try {
+        parsed = handler.parse(node.value);
+      } catch {
+        // A malformed frontmatter body is a Markdown-parser concern, not a
+        // schema-validation concern; skip it.
+        return;
+      }
+      // Several `GetLoc` helpers read their SourceCode argument, so build one for
+      // the sub-parse. Its ranges are relative to `node.value`.
+      const subSourceCode = new SourceCode({
+        text: node.value,
+        ast: parsed.ast as SourceCode.Program,
+      });
+      const fullText = sourceCode.getText();
+      // Offset in the real file where the frontmatter body begins.
+      const valueStart = fullText.indexOf(
+        node.value,
+        node.position.start.offset,
+      );
+      if (valueStart < 0) {
+        return;
+      }
+
+      validateData(handler.getStaticValue(parsed.ast), (error) => {
+        const errorData = handler.getNodeFromPath(parsed.ast, error.path);
+        const range = errorData.key
+          ? errorData.key(subSourceCode)
+          : errorData.value
+            ? errorData.value.range
+            : null;
+        if (!range) {
+          return null;
+        }
+        return {
+          start: sourceCode.getLocFromIndex(valueStart + range[0]),
+          end: sourceCode.getLocFromIndex(valueStart + range[1]),
+        };
+      });
+    }
+
     /** Find schema path from program */
     function findSchemaPathFromJSON(node: JSONAST.JSONProgram) {
       const rootExpr = node.body[0].expression;
@@ -264,12 +355,12 @@ export default createRule("no-invalid", {
 
     return {
       Program(node) {
-        if (sourceCode.parserServices.isJSON) {
+        if (sourceCode.parserServices?.isJSON) {
           const program = node as JSONAST.JSONProgram;
           validateData(getStaticJSONValue(program), (error) => {
             return errorDataToLoc(getJSONNodeFromPath(program, error.path));
           });
-        } else if (sourceCode.parserServices.isYAML) {
+        } else if (sourceCode.parserServices?.isYAML) {
           const program = node as YAML.YAMLProgram;
           validateData(getStaticYAMLValue(program), (error) => {
             const errorData = getYAMLNodeFromPath(program, error.path);
@@ -280,7 +371,7 @@ export default createRule("no-invalid", {
             }
             return errorDataToLoc(errorData);
           });
-        } else if (sourceCode.parserServices.isTOML) {
+        } else if (sourceCode.parserServices?.isTOML) {
           const program = node as TOML.TOMLProgram;
           validateData(getStaticTOMLValue(program), (error) => {
             return errorDataToLoc(getTOMLNodeFromPath(program, error.path));
@@ -315,6 +406,24 @@ export default createRule("no-invalid", {
         ) {
           validateJSExport(node.right, node.left.range);
         }
+      },
+      yaml(node: unknown) {
+        validateFrontmatter(
+          node as MarkdownFrontmatterNode,
+          FRONTMATTER_HANDLERS.yaml,
+        );
+      },
+      toml(node: unknown) {
+        validateFrontmatter(
+          node as MarkdownFrontmatterNode,
+          FRONTMATTER_HANDLERS.toml,
+        );
+      },
+      json(node: unknown) {
+        validateFrontmatter(
+          node as MarkdownFrontmatterNode,
+          FRONTMATTER_HANDLERS.json,
+        );
       },
     };
 
@@ -397,13 +506,13 @@ export default createRule("no-invalid", {
     /** Find schema path from program */
     function findSchemaPath(node: unknown) {
       let $schema = null;
-      if (sourceCode.parserServices.isJSON) {
+      if (sourceCode.parserServices?.isJSON) {
         const program = node as JSONAST.JSONProgram;
         $schema = findSchemaPathFromJSON(program);
-      } else if (sourceCode.parserServices.isYAML) {
+      } else if (sourceCode.parserServices?.isYAML) {
         const program = node as YAML.YAMLProgram;
         $schema = findSchemaPathFromYAML(program);
-      } else if (sourceCode.parserServices.isTOML) {
+      } else if (sourceCode.parserServices?.isTOML) {
         const program = node as TOML.TOMLProgram;
         $schema = findSchemaPathFromTOML(program);
       }

--- a/src/rules/no-invalid.ts
+++ b/src/rules/no-invalid.ts
@@ -320,9 +320,7 @@ export default createRule("no-invalid", {
         const errorData = handler.getNodeFromPath(parsed.ast, error.path);
         const range = errorData.key
           ? errorData.key(subSourceCode)
-          : errorData.value
-            ? errorData.value.range
-            : null;
+          : errorData.value.range;
         if (!range) {
           return null;
         }
@@ -407,6 +405,10 @@ export default createRule("no-invalid", {
           validateJSExport(node.right, node.left.range);
         }
       },
+      // Frontmatter nodes only appear under @eslint/markdown. Their lowercase
+      // mdast types (`yaml`/`toml`/`json`) never collide with the native data
+      // parsers, whose node types are capitalized (`JSON*`/`YAML*`/`TOML*`), so
+      // no parserServices guard is required here.
       yaml(node: unknown) {
         validateFrontmatter(
           node as MarkdownFrontmatterNode,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -39,7 +39,7 @@ export function createRule(
         filename,
       });
       if (
-        typeof sourceCode.parserServices.defineCustomBlocksVisitor ===
+        typeof sourceCode.parserServices?.defineCustomBlocksVisitor ===
           "function" &&
         path.extname(filename) === ".vue"
       ) {

--- a/tests/src/rules/no-invalid-frontmatter.ts
+++ b/tests/src/rules/no-invalid-frontmatter.ts
@@ -54,6 +54,25 @@ tester.run("no-invalid (markdown frontmatter)", rule as any, {
       options: OPTIONS,
       ...md("yaml"),
     },
+    {
+      // Frontmatter parsing disabled: `---` is not treated as frontmatter, so
+      // there is no frontmatter node and nothing is validated.
+      filename: "ok.md",
+      code: "---\nver: 9\n---\n# Title\n",
+      options: OPTIONS,
+      plugins: { markdown },
+      language: "markdown/commonmark",
+      // no languageOptions.frontmatter
+    },
+    {
+      // Malformed YAML frontmatter body: yaml-eslint-parser throws while
+      // parsing `foo: [unclosed`, so `validateFrontmatter`'s try/catch skips
+      // it rather than crashing or reporting anything.
+      filename: "ok.md",
+      code: "---\nfoo: [unclosed\n---\n# Title\n",
+      options: OPTIONS,
+      ...md("yaml"),
+    },
   ],
   invalid: [
     {
@@ -84,6 +103,21 @@ tester.run("no-invalid (markdown frontmatter)", rule as any, {
       options: OPTIONS,
       ...md("json"),
       errors: [{ message: '"ver" must be string.', line: 2 }],
+    },
+    {
+      filename: "bad.md",
+      code: "---\nname: x\ntitle: ok\nver: 9\n---\n# Title\n",
+      options: OPTIONS,
+      ...md("yaml"),
+      errors: [
+        {
+          message: '"ver" must be string.',
+          line: 4,
+          column: 1,
+          endLine: 4,
+          endColumn: 4,
+        },
+      ],
     },
   ],
 });

--- a/tests/src/rules/no-invalid-frontmatter.ts
+++ b/tests/src/rules/no-invalid-frontmatter.ts
@@ -1,0 +1,89 @@
+import { RuleTester } from "eslint";
+import markdown from "@eslint/markdown";
+import rule from "../../../src/rules/no-invalid.ts";
+
+/** Schema requiring `ver` to be a string. */
+const SCHEMA = {
+  type: "object",
+  properties: { ver: { type: "string" } },
+  additionalProperties: true,
+};
+
+/** Base config shared by every Markdown test case. */
+function md(frontmatter: "yaml" | "toml" | "json") {
+  return {
+    plugins: { markdown },
+    language: "markdown/commonmark" as const,
+    languageOptions: { frontmatter },
+  };
+}
+
+const OPTIONS = [
+  {
+    schemas: [{ fileMatch: ["*.md", "**/*.md"], schema: SCHEMA }],
+    useSchemastoreCatalog: false,
+  },
+];
+
+const tester = new RuleTester();
+
+tester.run("no-invalid (markdown frontmatter)", rule as any, {
+  valid: [
+    {
+      filename: "ok.md",
+      code: '---\nname: x\nver: "1.0"\n---\n# Title\n',
+      options: OPTIONS,
+      ...md("yaml"),
+    },
+    {
+      filename: "ok.md",
+      code: '+++\nname = "x"\nver = "1.0"\n+++\n# Title\n',
+      options: OPTIONS,
+      ...md("toml"),
+    },
+    {
+      filename: "ok.md",
+      code: '---\n{ "name": "x", "ver": "1.0" }\n---\n# Title\n',
+      options: OPTIONS,
+      ...md("json"),
+    },
+    {
+      // No frontmatter at all: nothing to validate.
+      filename: "ok.md",
+      code: "# Title\n\nBody text.\n",
+      options: OPTIONS,
+      ...md("yaml"),
+    },
+  ],
+  invalid: [
+    {
+      filename: "bad.md",
+      code: "---\nname: x\nver: 9\n---\n# Title\n",
+      options: OPTIONS,
+      ...md("yaml"),
+      errors: [
+        {
+          message: '"ver" must be string.',
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 4,
+        },
+      ],
+    },
+    {
+      filename: "bad.md",
+      code: '+++\nname = "x"\nver = 9\n+++\n# Title\n',
+      options: OPTIONS,
+      ...md("toml"),
+      errors: [{ message: '"ver" must be string.', line: 3 }],
+    },
+    {
+      filename: "bad.md",
+      code: '---\n{ "name": "x", "ver": 9 }\n---\n# Title\n',
+      options: OPTIONS,
+      ...md("json"),
+      errors: [{ message: '"ver" must be string.', line: 2 }],
+    },
+  ],
+});


### PR DESCRIPTION
Closes #419

## Summary

Automatically picks up frontmatter on the AST of registered MD files, in any supported format (JSON, TOML, or YAML), performing schema validation configurable in the same ways as for normal files.

If the upstream project is updated to [support MDX linting](https://github.com/eslint/markdown/issues/316), as long as the AST is supported in the same way, we should automatically inherit support, MD and MDX frontmatter is the same.

## Compatibility

This should be fully backwards compatible, as I'm unaware of any schemastore schema currently associated with MD(X) files. But for fully disclosure this would constitute a breaking change in the _extremely_ niche case of a user:

1. Having the Markdown plugin installed with frontmatter enabled.
2. Already having configured this plugin to trigger against MD(X) files.
3. That has explicitly set a schema in the frontmatter or has a schema catalogue that automatically associates their MD file with a schema.
4. And is violating that schema in the frontmatter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating YAML, TOML, and JSON frontmatter in Markdown files against configured JSON Schemas.
  * Reports validation errors at the relevant frontmatter locations.
* **Bug Fixes**
  * Improved handling when parser services are unavailable, preventing validation failures.
  * Malformed frontmatter is safely ignored instead of causing crashes.
* **Documentation**
  * Added configuration guidance and examples for validating Markdown frontmatter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->