### PR TITLE
Revert "chore(deps): update changesets/action action to v2"

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.0.0
+        uses: changesets/action@v1
         with:
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
           version: npm run version:ci


### PR DESCRIPTION
Reverts ota-meshi/eslint-plugin-json-schema-validator#525

---

Warning: Unexpected input(s) 'version', 'publish', 'commit', 'title', valid inputs are ['github-token', 'publish-script', 'version-script', 'commit-message', 'pr-title', 'pr-draft', 'pr-base-branch', 'create-github-releases', 'push-git-tags', 'push-with-git-cli']

Error: Error: This version of the Changesets action is designed to work with Changesets CLI v3. Changesets CLI v2 is not supported; use Changesets action v1 instead, which is compatible with CLI v2.
Error: This version of the Changesets action is designed to work with Changesets CLI v3. Changesets CLI v2 is not supported; use Changesets action v1 instead, which is compatible with CLI v2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release workflow to use the latest supported Changesets action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->